### PR TITLE
Fixed: unused volume issue when postgresql version 18 #104

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "${DB_PORT}:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
 
   pgadmin:
     image: dpage/pgadmin4


### PR DESCRIPTION
Error log from vault-web-db-1 container with latest (18) postgres image without any change in vault-web repo

> Error: in 18+, these Docker images are configured to store database data in a
>        format which is compatible with "pg_ctlcluster" (specifically, using
>        major-version-specific directory names).  This better reflects how
>        PostgreSQL itself works, and how upgrades are to be performed.
> 
>        See also https://github.com/docker-library/postgres/pull/1259
> 
>        Counter to that, there appears to be PostgreSQL data in:
>          /var/lib/postgresql/data (unused mount/volume)
> 
>        This is usually the result of upgrading the Docker image without
>        upgrading the underlying database using "pg_upgrade" (which requires both
>        versions).
> 
>        The suggested container configuration for 18+ is to place a single mount
>        at /var/lib/postgresql which will then place PostgreSQL data in a
>        subdirectory, allowing usage of "pg_upgrade --link" without mount point
>        boundary issues.
> 
>        See https://github.com/docker-library/postgres/issues/37 for a (long)
>        discussion around this process, and suggestions for how to do so.

Following the **error reason for (unused mount/volume)** - I've done change for volume in compose file. 

And in local test, below 2 expectations are passed -
1. vault-web-db-1 docker container is up and running with latest (postgres version 18) or old (postgres version 15) image.
2. Change is compatible with old and latest image tags for postgres. With both old-latest image, on UI operation in vaultdb docker container tables (vault_user, chat_message, .. etc) row(s) created.
