### PR TITLE
Add Logout Redirect and clear stored user data.

### DIFF
--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -10,8 +10,9 @@ import { Router } from '@angular/router';
 export class AuthService {
   private apiUrl = environment.mainApiUrl;
 
-  constructor(private http: HttpClient,
-     private router: Router 
+  constructor(
+    private http: HttpClient,
+    private router: Router,
   ) {}
 
   login(username: string, password: string): Observable<{ token: string }> {


### PR DESCRIPTION
This PR adds the missing logout functionality in AuthService.
Previously logging out removed only the token from the localStorage, but did not redirect the user to the login page.
Now, when the user logs out the token as well as username is cleared from the localStorage and then directed to the login page .