### PR TITLE
test: add UserController unit tests

### DIFF
--- a/backend/src/test/java/vaultWeb/controllers/UserControllerTest.java
+++ b/backend/src/test/java/vaultWeb/controllers/UserControllerTest.java
@@ -117,7 +117,7 @@ class UserControllerTest {
     when(userService.usernameExists(username)).thenReturn(true);
     ResponseEntity<Map<String, Boolean>> response = userController.checkUsernameExists(username);
     assertEquals(HttpStatus.OK, response.getStatusCode());
-    assertEquals(true, ((Map<String, Boolean>) response.getBody()).get("exists"));
+    assertEquals(true, (response.getBody()).get("exists"));
     verify(userService, times(1)).usernameExists(username);
   }
 
@@ -127,7 +127,7 @@ class UserControllerTest {
     when(userService.usernameExists(username)).thenReturn(false);
     ResponseEntity<Map<String, Boolean>> response = userController.checkUsernameExists(username);
     assertEquals(HttpStatus.OK, response.getStatusCode());
-    assertEquals(false, ((Map<String, Boolean>) response.getBody()).get("exists"));
+    assertEquals(false, (response.getBody()).get("exists"));
     verify(userService, times(1)).usernameExists(username);
   }
 
@@ -137,14 +137,11 @@ class UserControllerTest {
     when(userService.getAllUsers()).thenReturn(testUsers);
     ResponseEntity<List<UserResponseDto>> response = userController.getAllUsers();
     assertEquals(HttpStatus.OK, response.getStatusCode());
-    assertEquals(testUsers.size(), ((List<UserResponseDto>) response.getBody()).size());
+    List<UserResponseDto> users = response.getBody();
+    assertEquals(testUsers.size(), users.size());
     verify(userService, times(1)).getAllUsers();
-    assertEquals(
-        testUsers.get(0).getUsername(),
-        ((List<UserResponseDto>) response.getBody()).get(0).getUsername());
-    assertEquals(
-        testUsers.get(1).getUsername(),
-        ((List<UserResponseDto>) response.getBody()).get(1).getUsername());
+    assertEquals(testUsers.get(0).getUsername(), users.get(0).getUsername());
+    assertEquals(testUsers.get(1).getUsername(), users.get(1).getUsername());
   }
 
   @Test
@@ -185,9 +182,9 @@ class UserControllerTest {
     // Mock: authService.login() throws BadCredentialsException
     when(authService.login(userDto.getUsername(), userDto.getPassword()))
         .thenThrow(new BadCredentialsException("Invalid credentials"));
-
     // Act & Assert: Verify the exception is thrown (GlobalExceptionHandler handles it in real app)
     assertThrows(BadCredentialsException.class, () -> userController.login(userDto, responseMock));
+    verify(refreshTokenService, never()).create(any(User.class), any(HttpServletResponse.class));
   }
 
   @Test


### PR DESCRIPTION
## Summary
Add comprehensive unit tests for UserController to improve backend test coverage and establish testing patterns for remaining controllers.

## Linked issue

Closes #

## How to test

### New Test File
- **UserControllerTest.java** - 14 unit tests covering authentication and user management endpoints
  - 8 happy path tests
  - 6 error scenario tests
  - Follows existing DashboardControllerTest pattern
  - Uses JUnit 5 + Mockito (no Spring context loading)

**Endpoints Tested:**
- ✅ `POST /api/auth/register` - User registration
- ✅ `POST /api/auth/login` - User authentication with JWT tokens
- ✅ `POST /api/auth/refresh` - Token refresh with rotation
- ✅ `POST /api/auth/logout` - Token revocation
- ✅ `GET /api/auth/check-username` - Username availability check
- ✅ `GET /api/auth/users` - User list retrieval
- ✅ `POST /api/auth/change-password` - Password update

**Test Scenarios:**
- Happy paths with valid inputs
- Authentication failures (invalid credentials, missing tokens)
- Authorization failures (unauthenticated access)
- Duplicate username handling
- Null/empty input validation
**CI Pipeline Verification:**
- ✅ `./mvnw spotless:check` - Code formatting passes
- ✅ `./mvnw verify` - Full build + all tests pass
- ✅ All existing tests still passing (no regressions

## Notes / Risk

This is Phase 1 of a larger initiative to add unit tests for all backend controllers:
- ✅ Phase 1: UserController (14 tests) - **This PR**
- ⏳ Phase 2: GroupController (16 tests planned)
- ⏳ Phase 3: PollController (13 tests planned)
- ⏳ Phase 4: PrivateChatController (9 tests planned)
- ⏳ Phase 5: ChatController (8 tests planned)

**Total Goal:** 60 controller unit tests with 60-80% coverage

## Testing Philosophy

These are **unit tests**, not integration tests:
- Controller logic only (no Spring Security enforcement)
- Service methods are mocked (no database access)
- Fast execution for rapid feedback
- Integration tests will be added separately for end-to-end flows
