### PR TITLE
Add missing unit tests for UserService and AuthService

### DIFF
--- a/backend/src/test/java/vaultWeb/services/UserServiceTest.java
+++ b/backend/src/test/java/vaultWeb/services/UserServiceTest.java
@@ -10,24 +10,19 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
 import vaultWeb.exceptions.DuplicateUsernameException;
 import vaultWeb.exceptions.UnauthorizedException;
 import vaultWeb.models.User;
 import vaultWeb.repositories.UserRepository;
 
-
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
-  @Mock
-  private UserRepository userRepository;
+  @Mock private UserRepository userRepository;
 
-  @Mock
-  private PasswordEncoder passwordEncoder;
+  @Mock private PasswordEncoder passwordEncoder;
 
-  @InjectMocks
-  private UserService userService;
+  @InjectMocks private UserService userService;
 
   private User createUser(Long id, String username, String password) {
     User user = new User();
@@ -56,10 +51,7 @@ class UserServiceTest {
 
     when(userRepository.existsByUsername("existing")).thenReturn(true);
 
-    assertThrows(
-        DuplicateUsernameException.class,
-        () -> userService.registerUser(user)
-    );
+    assertThrows(DuplicateUsernameException.class, () -> userService.registerUser(user));
 
     verify(userRepository, never()).save(any());
   }
@@ -80,10 +72,7 @@ class UserServiceTest {
 
   @Test
   void shouldReturnAllUsers() {
-    List<User> users = List.of(
-        createUser(1L, "user1", "pwd1"),
-        createUser(2L, "user2", "pwd2")
-    );
+    List<User> users = List.of(createUser(1L, "user1", "pwd1"), createUser(2L, "user2", "pwd2"));
 
     when(userRepository.findAll()).thenReturn(users);
 
@@ -113,9 +102,7 @@ class UserServiceTest {
     when(passwordEncoder.matches("wrong", "oldHashed")).thenReturn(false);
 
     assertThrows(
-        UnauthorizedException.class,
-        () -> userService.changePassword(user, "wrong", "new")
-    );
+        UnauthorizedException.class, () -> userService.changePassword(user, "wrong", "new"));
 
     verify(userRepository, never()).save(any());
   }

--- a/backend/src/test/java/vaultWeb/services/auth/AuthServiceTest.java
+++ b/backend/src/test/java/vaultWeb/services/auth/AuthServiceTest.java
@@ -14,7 +14,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-
 import vaultWeb.models.User;
 import vaultWeb.repositories.RefreshTokenRepository;
 import vaultWeb.repositories.UserRepository;
@@ -23,23 +22,17 @@ import vaultWeb.security.JwtUtil;
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
-  @Mock
-  private AuthenticationManager authenticationManager;
+  @Mock private AuthenticationManager authenticationManager;
 
-  @Mock
-  private JwtUtil jwtUtil;
+  @Mock private JwtUtil jwtUtil;
 
-  @Mock
-  private UserRepository userRepository;
+  @Mock private UserRepository userRepository;
 
-  @Mock
-  private RefreshTokenRepository refreshTokenRepository;
+  @Mock private RefreshTokenRepository refreshTokenRepository;
 
-  @Mock
-  private RefreshTokenService refreshTokenService;
+  @Mock private RefreshTokenService refreshTokenService;
 
-  @InjectMocks
-  private AuthService authService;
+  @InjectMocks private AuthService authService;
 
   private User createUser(String username, String password) {
     User user = new User();
@@ -55,13 +48,12 @@ class AuthServiceTest {
 
     when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
         .thenReturn(authentication);
-    when(authentication.getPrincipal()).thenReturn(
-        org.springframework.security.core.userdetails.User
-            .withUsername("testuser")
-            .password("hashedPwd")
-            .authorities("ROLE_USER")
-            .build()
-    );
+    when(authentication.getPrincipal())
+        .thenReturn(
+            org.springframework.security.core.userdetails.User.withUsername("testuser")
+                .password("hashedPwd")
+                .authorities("ROLE_USER")
+                .build());
     when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
     when(jwtUtil.generateToken(user)).thenReturn("jwt-token");
 
@@ -78,10 +70,7 @@ class AuthServiceTest {
     when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
         .thenThrow(new BadCredentialsException("Bad credentials"));
 
-    assertThrows(
-        BadCredentialsException.class,
-        () -> authService.login("unknown", "password")
-    );
+    assertThrows(BadCredentialsException.class, () -> authService.login("unknown", "password"));
   }
 
   @Test
@@ -89,9 +78,6 @@ class AuthServiceTest {
     when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
         .thenThrow(new BadCredentialsException("Bad credentials"));
 
-    assertThrows(
-        BadCredentialsException.class,
-        () -> authService.login("testuser", "wrong")
-    );
+    assertThrows(BadCredentialsException.class, () -> authService.login("testuser", "wrong"));
   }
 }


### PR DESCRIPTION
Related to #109

This PR adds missing unit tests for the User Management service layer.

What was added:
- UserServiceTest: covers registration, username checks, user listing, and password change logic
- AuthServiceTest: covers authentication/login success and failure cases

Notes:
- Controller tests already existed and were not modified
- Tests are written with JUnit 5 and Mockito
- All tests are fast, isolated, and do not depend on DB or network

Test verification:
- ./mvnw test passes successfully (27 tests, 0 failures)

![Test output ](https://github.com/user-attachments/assets/e96a697e-33da-4b1c-94cd-e6eb1c670bd6)
