### PR TITLE
Add unit tests for group management services

### DIFF
--- a/backend/src/test/java/vaultWeb/services/GroupServiceTest.java
+++ b/backend/src/test/java/vaultWeb/services/GroupServiceTest.java
@@ -244,7 +244,7 @@ class GroupServiceTest {
 
     assertEquals("Updated Name", result.getName());
     assertEquals("Updated Description", result.getDescription());
-    assertEquals(false, result.getIsPublic());
+    assertFalse(result.getIsPublic());
     verify(groupRepository, times(1)).save(group);
   }
 


### PR DESCRIPTION
Fixes #109

This PR completes Issue #109 by adding unit tests for the **Group Management** service layer, finalizing full test coverage across user, chat, and group management.

### What was added
- **GroupServiceTest (21 tests)** covering:
  - Create, update, delete groups
  - Join/leave groups
  - Get members
  - Remove members with role enforcement (ADMIN/USER)
  - Edge cases: group not found, user not found, already member, last admin removal

### Final coverage status
- User management: ✅ complete
- Chat management: ✅ complete
- Group management: ✅ complete  
- **Total tests:** 46

### Notes
- Tests use **JUnit 5** and **Mockito**
- All tests are isolated, fast, and do not depend on DB or network

![GroupServiceTest_Output](https://github.com/user-attachments/assets/35f7a8c8-d176-482a-a95a-9eff870894cd)