### PR TITLE
fix(cloud): improve dark mode readability by updating styles and clas…

### DIFF
--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -1,4 +1,4 @@
-<div class="cloud-container min-h-screen p-2 sm:p-3">
+<div class="cloud-container p-2 sm:p-3">
   <!-- Header -->
   <div class="flex justify-between items-center mb-1 sm:mb-2">
     <h1 class="cloud-title text-base sm:text-lg font-semibold">Cloud Page</h1>
@@ -43,7 +43,7 @@
     >
       <span>/</span>
       <span
-        class="truncate max-w-[80px] sm:max-w-[120px] cursor-pointer hover:underline"
+        class="truncate max-w-[80px] sm:max-w-[120px]"
         [class.font-semibold]="last"
         [class.cloud-link]="!last"
         (click)="!last && navigateToFolder(crumb.path)"
@@ -69,19 +69,19 @@
     >
       <button
         (click)="createNewFolder(); showCreateDropdown = false"
-        class="w-full text-left px-1.5 sm:px-2 py-1 hover:bg-gray-100 flex items-center gap-1"
+        class="w-full text-left px-1.5 sm:px-2 py-1 flex items-center gap-1"
       >
         📁 Folder
       </button>
       <button
         (click)="createNewFile(); showCreateDropdown = false"
-        class="w-full text-left px-1.5 sm:px-2 py-1 hover:bg-gray-100 flex items-center gap-1"
+        class="w-full text-left px-1.5 sm:px-2 py-1 flex items-center gap-1"
       >
         📄 File
       </button>
       <label
         for="file-upload-dropdown"
-        class="w-full text-left px-1.5 sm:px-2 py-1 hover:bg-gray-100 flex items-center gap-1 cursor-pointer"
+        class="w-full text-left px-1.5 sm:px-2 py-1 flex items-center gap-1 cursor-pointer"
       >
         ⬆️ Upload
         <input

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -1,22 +1,19 @@
-<div class="cloud-container bg-gray-50 min-h-screen p-2 sm:p-3">
+<div class="cloud-container min-h-screen p-2 sm:p-3">
   <!-- Header -->
   <div class="flex justify-between items-center mb-1 sm:mb-2">
-    <h1 class="text-base sm:text-lg font-semibold text-gray-800">Cloud Page</h1>
+    <h1 class="cloud-title text-base sm:text-lg font-semibold">Cloud Page</h1>
     <button
       (click)="reloadRootFolder()"
-      class="px-1.5 py-0.5 sm:px-2 sm:py-1 bg-gray-300 text-gray-800 text-xxs sm:text-xs rounded hover:bg-gray-400 transition"
+      class="cloud-btn px-1.5 py-0.5 sm:px-2 sm:py-1 text-xxs sm:text-xs rounded transition"
     >
       ↻ Refresh
     </button>
   </div>
 
   <!-- Loading & Error -->
-  <div
-    *ngIf="loading"
-    class="text-center py-2 text-gray-600 text-xxs sm:text-xs"
-  >
+  <div *ngIf="loading" class="text-center py-2 cloud-muted text-xxs sm:text-xs">
     <div
-      class="animate-spin h-4 w-4 border-b-2 border-gray-600 mx-auto mb-1"
+      class="animate-spin h-4 w-4 border-b-2 border-current mx-auto mb-1"
     ></div>
     Loading folder...
   </div>
@@ -34,7 +31,7 @@
     class="flex items-center text-xxs sm:text-xs mb-1 sm:mb-2 gap-1 flex-wrap"
   >
     <span
-      class="cursor-pointer text-blue-600"
+      class="cloud-link cursor-pointer"
       (click)="navigateToRoot()"
       (dragover)="onBreadcrumbDragOver($event)"
       (drop)="onBreadcrumbDrop($event, rootPath)"
@@ -46,10 +43,9 @@
     >
       <span>/</span>
       <span
-        class="truncate max-w-[80px] sm:max-w-[120px]"
+        class="truncate max-w-[80px] sm:max-w-[120px] cursor-pointer hover:underline"
         [class.font-semibold]="last"
-        [class.text-blue-600]="!last"
-        class="cursor-pointer hover:underline"
+        [class.cloud-link]="!last"
         (click)="!last && navigateToFolder(crumb.path)"
         (dragover)="onBreadcrumbDragOver($event)"
         (drop)="onBreadcrumbDrop($event, crumb.path)"
@@ -63,13 +59,13 @@
   <div class="relative mb-1 sm:mb-2 flex gap-1 sm:gap-2">
     <button
       (click)="showCreateDropdown = !showCreateDropdown"
-      class="px-1.5 py-0.5 sm:px-2 sm:py-1 bg-gray-200 text-gray-800 text-xxs sm:text-xs rounded hover:bg-gray-300 transition"
+      class="cloud-btn px-1.5 py-0.5 sm:px-2 sm:py-1 text-xxs sm:text-xs rounded transition"
     >
       Create
     </button>
     <div
       *ngIf="showCreateDropdown"
-      class="absolute mt-5 sm:mt-6 bg-white border border-gray-200 rounded shadow-md z-10 w-28 sm:w-32 text-xxs sm:text-xs"
+      class="cloud-dropdown absolute mt-5 sm:mt-6 rounded shadow-md z-10 w-28 sm:w-32 text-xxs sm:text-xs"
     >
       <button
         (click)="createNewFolder(); showCreateDropdown = false"
@@ -101,10 +97,10 @@
   <!-- File Explorer Table -->
   <div
     *ngIf="currentFolder && !loading"
-    class="bg-white shadow rounded overflow-x-auto"
+    class="cloud-card shadow rounded overflow-x-auto"
   >
     <table class="w-full table-auto border-collapse text-xxs sm:text-xs">
-      <thead class="bg-gray-100 sticky top-0">
+      <thead class="cloud-thead sticky top-0">
         <tr>
           <th class="text-left px-1 py-0.5 sm:px-2 sm:py-1">Name</th>
           <th class="text-left px-1 py-0.5 sm:px-2 sm:py-1">Size</th>
@@ -116,7 +112,7 @@
         <!-- Folders -->
         <tr
           *ngFor="let folder of currentFolder.folders"
-          class="hover:bg-gray-50 cursor-pointer"
+          class="cloud-row cursor-pointer"
           (drop)="onDrop($event, folder, true)"
           (dragover)="onDragOver($event)"
         >
@@ -128,10 +124,10 @@
           >
             📁 {{ folder.name }}
           </td>
-          <td class="px-1 py-0.5 sm:px-2 sm:py-1 text-gray-500">
+          <td class="px-1 py-0.5 sm:px-2 sm:py-1 cloud-muted">
             {{ folder.folders.length + folder.files.length }} items
           </td>
-          <td class="px-1 py-0.5 sm:px-2 sm:py-1 text-gray-500">Folder</td>
+          <td class="px-1 py-0.5 sm:px-2 sm:py-1 cloud-muted">Folder</td>
           <td class="px-1 py-0.5 sm:px-2 sm:py-1 text-center">
             <button
               (click)="$event.stopPropagation(); renameFolder(folder)"
@@ -151,7 +147,7 @@
         <!-- Files -->
         <tr
           *ngFor="let file of currentFolder.files"
-          class="hover:bg-gray-50"
+          class="cloud-row"
           (drop)="onDrop($event, null, false)"
           (dragover)="onDragOver($event)"
         >
@@ -201,7 +197,7 @@
         >
           <td
             colspan="4"
-            class="text-center py-3 sm:py-6 text-gray-400 text-xxs sm:text-xs"
+            class="text-center py-3 sm:py-6 cloud-muted text-xxs sm:text-xs"
           >
             This folder is empty. Create a new folder or file.
           </td>
@@ -213,17 +209,17 @@
   <!-- File Editor Modal -->
   <div
     *ngIf="showFileEditor"
-    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-1 sm:p-2"
+    class="modal-overlay fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-1 sm:p-2"
   >
     <div
-      class="bg-white w-full max-w-md p-2 sm:p-3 rounded shadow-lg flex flex-col"
+      class="cloud-modal w-full max-w-md p-2 sm:p-3 rounded shadow-lg flex flex-col"
     >
       <div class="flex justify-between items-center mb-1 sm:mb-2">
         <h2 class="font-semibold text-xs sm:text-sm">
           {{ editingFile ? "Edit File" : "Create New File" }}
         </h2>
         <button
-          class="text-gray-500 hover:text-gray-800 text-xs sm:text-sm"
+          class="cloud-close text-xs sm:text-sm"
           (click)="showFileEditor = false"
         >
           ✖️
@@ -232,16 +228,16 @@
       <input
         type="text"
         [(ngModel)]="newFileName"
-        class="border p-1 sm:p-2 rounded mb-1 sm:mb-2 w-full text-xxs sm:text-xs"
+        class="cloud-input p-1 sm:p-2 rounded mb-1 sm:mb-2 w-full text-xxs sm:text-xs"
         placeholder="filename.txt"
       />
       <textarea
         [(ngModel)]="fileContent"
-        class="border p-1 sm:p-2 rounded h-32 sm:h-48 w-full font-mono mb-1 sm:mb-2 text-xxs sm:text-xs"
+        class="cloud-input cloud-textarea p-1 sm:p-2 rounded h-32 sm:h-48 w-full font-mono mb-1 sm:mb-2 text-xxs sm:text-xs"
       ></textarea>
       <div class="flex justify-end gap-1 sm:gap-2">
         <button
-          class="px-1.5 py-0.5 sm:px-2 sm:py-1 bg-gray-300 rounded hover:bg-gray-400 text-xxs sm:text-xs"
+          class="cloud-btn px-1.5 py-0.5 sm:px-2 sm:py-1 rounded text-xxs sm:text-xs"
           (click)="showFileEditor = false"
         >
           Cancel

--- a/frontend/src/app/pages/cloud/cloud.component.scss
+++ b/frontend/src/app/pages/cloud/cloud.component.scss
@@ -15,6 +15,11 @@
 
 .cloud-link {
   color: var(--color-primary);
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .cloud-btn {
@@ -37,7 +42,7 @@
     color: var(--color-text-primary);
 
     &:hover {
-      background-color: var(--color-surface-hover) !important;
+      background-color: var(--color-surface-hover);
     }
   }
 }
@@ -56,7 +61,7 @@
   border-bottom: 1px solid var(--color-border);
 
   &:hover {
-    background-color: var(--color-surface-hover) !important;
+    background-color: var(--color-surface-hover);
   }
 }
 

--- a/frontend/src/app/pages/cloud/cloud.component.scss
+++ b/frontend/src/app/pages/cloud/cloud.component.scss
@@ -1,11 +1,23 @@
 /* Cloud Component Theme Styles */
 .cloud-container {
   background-color: var(--color-background-secondary);
+  color: var(--color-text-primary);
   min-height: 100vh;
 }
 
-/* Buttons */
-button {
+.cloud-title {
+  color: var(--color-text-primary);
+}
+
+.cloud-muted {
+  color: var(--color-text-secondary);
+}
+
+.cloud-link {
+  color: var(--color-primary);
+}
+
+.cloud-btn {
   background-color: var(--color-surface);
   color: var(--color-text-primary);
   border: 1px solid var(--color-border);
@@ -15,54 +27,73 @@ button {
   }
 }
 
-/* Table Styles */
-table {
-  background-color: var(--color-surface);
-  color: var(--color-text-primary);
-
-  thead {
-    background-color: var(--color-background-secondary);
-    color: var(--color-text-secondary);
-  }
-
-  tbody tr {
-    border-bottom: 1px solid var(--color-border);
-
-    &:hover {
-      background-color: var(--color-surface-hover);
-    }
-  }
-}
-
-/* Modal Styles */
-.modal-overlay {
-  background-color: var(--color-surface);
-
-  input,
-  textarea {
-    background-color: var(--color-input-bg);
-    color: var(--color-text-primary);
-    border: 1px solid var(--color-input-border);
-
-    &:focus {
-      border-color: var(--color-input-focus-border);
-      outline: none;
-    }
-  }
-}
-
-/* Dropdown */
-.dropdown-menu {
+.cloud-dropdown {
   background-color: var(--color-surface);
   border: 1px solid var(--color-border);
-  box-shadow: 0 4px 6px var(--color-shadow);
+  color: var(--color-text-primary);
 
   button,
   label {
     color: var(--color-text-primary);
 
     &:hover {
-      background-color: var(--color-surface-hover);
+      background-color: var(--color-surface-hover) !important;
     }
   }
+}
+
+.cloud-card {
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.cloud-thead {
+  background-color: var(--color-background-secondary);
+  color: var(--color-text-secondary);
+}
+
+.cloud-row {
+  border-bottom: 1px solid var(--color-border);
+
+  &:hover {
+    background-color: var(--color-surface-hover) !important;
+  }
+}
+
+/* Modal Styles */
+.modal-overlay {
+  backdrop-filter: blur(1px);
+}
+
+.cloud-modal {
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+}
+
+.cloud-close {
+  color: var(--color-text-secondary);
+
+  &:hover {
+    color: var(--color-text-primary);
+  }
+}
+
+.cloud-input {
+  background-color: var(--color-input-bg);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-input-border);
+
+  &::placeholder {
+    color: var(--color-text-muted);
+  }
+
+  &:focus {
+    border-color: var(--color-input-focus-border);
+    outline: none;
+  }
+}
+
+.cloud-textarea {
+  resize: vertical;
 }


### PR DESCRIPTION
- [x] Remove `hover:bg-gray-100` from dropdown items in `cloud.component.html`
- [x] Drop `!important` from dropdown hover in `cloud.component.scss`
- [x] Drop `!important` from `.cloud-row:hover` in `cloud.component.scss`
- [x] Only apply `cursor-pointer` / `hover:underline` to breadcrumb when `!last` (moved into `.cloud-link` SCSS class)
- [x] Remove redundant `min-h-screen` from `cloud.component.html:1`
- [x] Code review and security check