### PR TITLE
Feature/ Implemented Expand/Collapse for "All Users" sections in home…

### DIFF
--- a/frontend/src/app/pages/home/home.component.html
+++ b/frontend/src/app/pages/home/home.component.html
@@ -96,13 +96,28 @@
     </div>
 
     <div *ngIf="filteredUsers.length > 0">
-      <div
-        class="section-heading text-xs font-semibold text-gray-600 px-4 py-2 uppercase"
+      <button
+        type="button"
+        class="section-heading px-4 py-2 w-full flex items-center justify-between text-xs font-semibold text-gray-600 uppercase hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 transition"
+        (click)="toggleUserExpansion()"
+        [attr.aria-expanded]="isAllUsersExpanded"
+        aria-controls="all-users-list"
       >
-        All Users
-      </div>
+        <span> All Users</span>
+        <i
+          class="pi transition-transform duration-200"
+          [class.pi-chevron-down]="!isAllUsersExpanded"
+          [class.pi-chevron-up]="isAllUsersExpanded"
+          aria-hidden="true"
+        ></i>
+      </button>
 
-      <ul *ngIf="!isLoading && !error" class="divide-y divide-gray-200">
+      <ul
+        id="all-users-list"
+        role="list"
+        *ngIf="isAllUsersExpanded"
+        class="divide-y divide-gray-200"
+      >
         <li
           *ngFor="let user of filteredUsers"
           (click)="openChat(user.username)"

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -48,6 +48,8 @@ export class HomeComponent implements OnInit {
   searchText: string = '';
   filteredUsers: UserDto[] = [];
   filteredPrivateChats: PrivateChatDto[] = [];
+  isAllUsersExpanded = false;
+  private readonly USER_EXPANSION_SESSION_KEY = 'homeAllUsersSessionKey';
 
   private isHttpStatusZero(err: unknown): boolean {
     const candidate = err as { status?: number };
@@ -82,6 +84,8 @@ export class HomeComponent implements OnInit {
       return;
     }
     this.loadData();
+    const saved = sessionStorage.getItem(this.USER_EXPANSION_SESSION_KEY);
+    this.isAllUsersExpanded = saved === 'true'; //default false
   }
 
   private loadData() {
@@ -309,5 +313,13 @@ export class HomeComponent implements OnInit {
 
   private matchUserName(userName: string, term: string): boolean {
     return userName.toLowerCase().includes(term.toLowerCase());
+  }
+
+  toggleUserExpansion() {
+    this.isAllUsersExpanded = !this.isAllUsersExpanded;
+    sessionStorage.setItem(
+      this.USER_EXPANSION_SESSION_KEY,
+      String(this.isAllUsersExpanded),
+    );
   }
 }


### PR DESCRIPTION
Home page

## Summary

- “All Users” is collapsed by default.
- “All Users” can be expanded and collapsed reliably.
- Persist UI state during current session/navigation where appropriate.
- Ensure keyboard accessibility (Enter/Space) and screen-reader labels.
- Keep search/filter behavior working when section is collapsed/expanded.
- Maintain consistent styling with current chat UI design.


## Linked issue

[Issue 204](https://github.com/Vault-Web/vault-web/issues/204)

## Demo:
<img width="785" height="315" alt="image" src="https://github.com/user-attachments/assets/f41d1ab7-f588-454a-af5f-158aafc1d12b" />

<img width="822" height="425" alt="image" src="https://github.com/user-attachments/assets/da64d3f6-ee06-4dce-b014-bff4a4dac246" />


