### PR TITLE
feat: show folder sizes in cloud view (consume /folders/content)

### DIFF
--- a/frontend/src/app/models/dtos/FolderContentItemDto.ts
+++ b/frontend/src/app/models/dtos/FolderContentItemDto.ts
@@ -1,0 +1,8 @@
+export interface FolderContentItemDto {
+  name: string;
+  path: string;
+  directory: boolean;
+  size: number;
+  mimeType: string | null;
+  lastModifiedAt: number;
+}

--- a/frontend/src/app/models/dtos/PageResponseDto.ts
+++ b/frontend/src/app/models/dtos/PageResponseDto.ts
@@ -1,0 +1,6 @@
+export interface PageResponseDto<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  pageNumber: number;
+}

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -68,6 +68,7 @@
       [lazy]="true"
       [paginator]="totalElements > pageSize"
       [rows]="pageSize"
+      [first]="contentFirst"
       [totalRecords]="totalElements"
       (onLazyLoad)="onPageChange($event)"
       styleClass="cloud-table text-xxs sm:text-xs"

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -65,6 +65,11 @@
   <section *ngIf="currentFolder && !loading" class="cloud-table-wrap">
     <p-table
       [value]="entries"
+      [lazy]="true"
+      [paginator]="totalElements > pageSize"
+      [rows]="pageSize"
+      [totalRecords]="totalElements"
+      (onLazyLoad)="onPageChange($event)"
       styleClass="cloud-table text-xxs sm:text-xs"
       [tableStyle]="{ 'min-width': '100%' }"
     >

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -81,6 +81,7 @@ export class CloudComponent implements OnInit {
   pageSize = 50;
   totalElements = 0;
   private contentPage = 0;
+  private contentRequestId = 0;
 
   private draggedPath: string | null = null;
   private draggedIsFolder = false;
@@ -153,16 +154,21 @@ export class CloudComponent implements OnInit {
   }
 
   private loadFolderContent(relativePath: string, page: number) {
+    // Guard against out-of-order responses: when the user navigates or pages
+    // quickly, an earlier (slower) request must not overwrite newer state.
+    const requestId = ++this.contentRequestId;
     this.cloudService
       .getFolderContent(relativePath, page, this.pageSize)
       .subscribe({
         next: (contentPage) => {
+          if (requestId !== this.contentRequestId) return;
           this.entries = this.buildEntries(contentPage.content);
           this.totalElements = contentPage.totalElements;
           this.contentPage = contentPage.pageNumber;
           this.loading = false;
         },
         error: () => {
+          if (requestId !== this.contentRequestId) return;
           this.error = 'Error loading folder contents';
           this.toast.error(
             'Could not load folder',

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -9,10 +9,11 @@ import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
 import { Menu } from 'primeng/menu';
 import { MenuModule } from 'primeng/menu';
-import { TableModule } from 'primeng/table';
+import { TableLazyLoadEvent, TableModule } from 'primeng/table';
 import { ToolbarModule } from 'primeng/toolbar';
 import { FileDto } from '../../models/dtos/FileDto';
 import { FolderDto } from '../../models/dtos/FolderDto';
+import { FolderContentItemDto } from '../../models/dtos/FolderContentItemDto';
 import { CloudService } from '../../services/cloud.service';
 import { finalize, firstValueFrom } from 'rxjs';
 import { UiToastService } from '../../core/services/ui-toast.service';
@@ -77,6 +78,10 @@ export class CloudComponent implements OnInit {
   entries: CloudEntry[] = [];
   downloadingPaths = new Set<string>();
 
+  pageSize = 50;
+  totalElements = 0;
+  private contentPage = 0;
+
   private draggedPath: string | null = null;
   private draggedIsFolder = false;
 
@@ -134,31 +139,53 @@ export class CloudComponent implements OnInit {
   }
 
   get totalItemsInView(): number {
-    if (!this.currentFolder) return 0;
-    return this.currentFolder.folders.length + this.currentFolder.files.length;
+    return this.totalElements;
   }
 
-  private buildEntries(folder: FolderDto): CloudEntry[] {
-    const folderEntries: CloudEntry[] = folder.folders.map((entryFolder) => ({
-      kind: 'folder',
-      name: entryFolder.name,
-      path: entryFolder.path,
-      sizeLabel:
-        entryFolder.directChildrenCount >= 0
-          ? `${entryFolder.directChildrenCount} items`
-          : '-',
-      typeLabel: 'Folder',
+  private buildEntries(items: FolderContentItemDto[]): CloudEntry[] {
+    return items.map((item) => ({
+      kind: item.directory ? 'folder' : 'file',
+      name: item.name,
+      path: item.path,
+      sizeLabel: this.formatFileSize(item.size),
+      typeLabel: item.directory ? 'Folder' : item.mimeType || 'Unknown',
     }));
+  }
 
-    const fileEntries: CloudEntry[] = folder.files.map((entryFile) => ({
-      kind: 'file',
-      name: entryFile.name,
-      path: entryFile.path,
-      sizeLabel: this.formatFileSize(entryFile.size),
-      typeLabel: entryFile.mimeType || 'Unknown',
-    }));
+  private loadFolderContent(relativePath: string, page: number) {
+    this.cloudService
+      .getFolderContent(relativePath, page, this.pageSize)
+      .subscribe({
+        next: (contentPage) => {
+          this.entries = this.buildEntries(contentPage.content);
+          this.totalElements = contentPage.totalElements;
+          this.contentPage = contentPage.pageNumber;
+          this.loading = false;
+        },
+        error: () => {
+          this.error = 'Error loading folder contents';
+          this.toast.error(
+            'Could not load folder',
+            'Folder contents are unavailable.',
+          );
+          this.loading = false;
+        },
+      });
+  }
 
-    return [...folderEntries, ...fileEntries];
+  onPageChange(event: TableLazyLoadEvent) {
+    const rows = event.rows ?? this.pageSize;
+    const first = Array.isArray(event.first)
+      ? (event.first[0] ?? 0)
+      : (event.first ?? 0);
+    const page = Math.floor(first / rows);
+    if (page === this.contentPage && rows === this.pageSize) return;
+    this.pageSize = rows;
+    this.loading = true;
+    const relativePath = this.getRelativePath(
+      this.currentFolder?.path || this.rootPath,
+    );
+    this.loadFolderContent(relativePath, page);
   }
 
   loadRootFolder() {
@@ -167,10 +194,9 @@ export class CloudComponent implements OnInit {
     this.cloudService.getRootFolder(false).subscribe({
       next: (folder) => {
         this.currentFolder = folder;
-        this.entries = this.buildEntries(folder);
         this.rootPath = folder.path;
         this.updateBreadcrumbs(folder.path);
-        this.loading = false;
+        this.loadFolderContent('/', 0);
       },
       error: () => {
         this.error = 'Error loading root folder';
@@ -193,9 +219,8 @@ export class CloudComponent implements OnInit {
     this.cloudService.getFolderByPath(relativePath, false).subscribe({
       next: (folder) => {
         this.currentFolder = folder;
-        this.entries = this.buildEntries(folder);
         this.updateBreadcrumbs(folder.path);
-        this.loading = false;
+        this.loadFolderContent(relativePath, 0);
       },
       error: () => {
         this.error = 'Error navigating to folder';

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -80,6 +80,7 @@ export class CloudComponent implements OnInit {
 
   pageSize = 50;
   totalElements = 0;
+  contentFirst = 0;
   private contentPage = 0;
   private contentRequestId = 0;
 
@@ -186,6 +187,7 @@ export class CloudComponent implements OnInit {
       : (event.first ?? 0);
     const page = Math.floor(first / rows);
     if (page === this.contentPage && rows === this.pageSize) return;
+    this.contentFirst = first;
     this.pageSize = rows;
     this.loading = true;
     const relativePath = this.getRelativePath(
@@ -197,6 +199,7 @@ export class CloudComponent implements OnInit {
   loadRootFolder() {
     this.loading = true;
     this.error = undefined;
+    this.contentFirst = 0;
     this.cloudService.getRootFolder(false).subscribe({
       next: (folder) => {
         this.currentFolder = folder;
@@ -221,6 +224,7 @@ export class CloudComponent implements OnInit {
 
   navigateToFolder(folderPath?: string) {
     this.loading = true;
+    this.contentFirst = 0;
     const relativePath = this.getRelativePath(folderPath || this.rootPath);
     this.cloudService.getFolderByPath(relativePath, false).subscribe({
       next: (folder) => {

--- a/frontend/src/app/services/cloud.service.ts
+++ b/frontend/src/app/services/cloud.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { FolderDto } from '../models/dtos/FolderDto';
+import { FolderContentItemDto } from '../models/dtos/FolderContentItemDto';
+import { PageResponseDto } from '../models/dtos/PageResponseDto';
 import { environment } from '../../environments/environment';
 
 @Injectable({
@@ -34,6 +36,26 @@ export class CloudService {
       .set('path', path)
       .set('includeChildCounts', String(includeChildCounts));
     return this.http.get<FolderDto>(`${this.apiUrl}/folders/path`, { params });
+  }
+
+  getFolderContent(
+    relativePath?: string,
+    page = 0,
+    size = 50,
+    sort?: string,
+  ): Observable<PageResponseDto<FolderContentItemDto>> {
+    const path = this.normalizePath(relativePath);
+    let params = new HttpParams()
+      .set('path', path)
+      .set('page', String(page))
+      .set('size', String(size));
+    if (sort) {
+      params = params.set('sort', sort);
+    }
+    return this.http.get<PageResponseDto<FolderContentItemDto>>(
+      `${this.apiUrl}/folders/content`,
+      { params },
+    );
   }
 
   getFileContent(relativePath: string): Observable<string> {


### PR DESCRIPTION
Closes #230.

Thanks for opening this follow-up, @DenizAltunkapan — happy to carry the feature through to the UI.

## What

The cloud view rendered the **Size** column for folders as an item count (`N items`), because it consumed `GET /folders` whose `FolderListItemDto` has no `size`. This switches the entry listing to the paginated `GET /folders/content` endpoint — which reports each folder's recursive size since Vault-Web/cloud-page#75 — and renders it with `formatFileSize(...)`, same as files.

## Changes

- **`CloudService`** — new `getFolderContent(relativePath, page, size, sort)` calling `GET /folders/content`.
- **Models** — `FolderContentItemDto` (with `size`) and `PageResponseDto<T>`, mirroring the backend DTOs.
- **`CloudComponent`** — entries are now built from the content page (folders and files come in one list with a `directory` flag); folder rows show their recursive size via `formatFileSize(...)`. Navigation, breadcrumbs and file operations keep using the existing folder endpoints, so behavior there is unchanged.
- **Template** — table wired to PrimeNG lazy pagination (`onLazyLoad`); the paginator only appears when the folder has more entries than one page. Pagination keeps the backend size-walk bounded to the current page, which ties into the cloud-page#62 performance concern.

## Verification

- `npm run build` — succeeds (strict template type-checking included).
- `prettier --check` on the changed files — clean.
- Empty folders render `0 Bytes` via the existing `formatFileSize(0)` branch; nested folder sizes come straight from the backend's recursive sum (covered by tests in cloud-page#75).