### PR TITLE
feat: add trash UI for cloud view (consume /files/trash endpoints)

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { authGuard } from './auth.guard';
 import { HomeComponent } from './pages/home/home.component';
 import { RegisterComponent } from './pages/register/register.component';
 import { CloudComponent } from './pages/cloud/cloud.component';
+import { TrashComponent } from './pages/cloud/trash/trash.component';
 import { DashboardComponent } from './pages/dashboard/dashboard.component';
 import { PasswordManagerComponent } from './pages/password-manager/password-manager.component';
 
@@ -23,5 +24,6 @@ export const routes: Routes = [
   { path: 'password-manager', redirectTo: 'passwords', pathMatch: 'full' },
   { path: 'register', component: RegisterComponent },
   { path: 'cloud', component: CloudComponent, canActivate: [authGuard] },
+  { path: 'cloud/trash', component: TrashComponent, canActivate: [authGuard] },
   { path: '**', redirectTo: 'login' },
 ];

--- a/frontend/src/app/models/dtos/TrashEntryDto.ts
+++ b/frontend/src/app/models/dtos/TrashEntryDto.ts
@@ -1,0 +1,7 @@
+export interface TrashEntryDto {
+  id: string;
+  name: string;
+  originalPath: string;
+  deletedAt: string;
+  size: number;
+}

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -8,13 +8,22 @@
         {{ totalItemsInView }} items in this folder
       </p>
     </div>
-    <p-button
-      label="Refresh"
-      icon="pi pi-refresh"
-      [outlined]="true"
-      styleClass="p-button-sm cloud-accent-btn text-xxs sm:text-xs"
-      (click)="reloadRootFolder()"
-    ></p-button>
+    <div class="cloud-headline-actions" style="display: flex; gap: 0.5rem">
+      <p-button
+        label="Trash"
+        icon="pi pi-trash"
+        [outlined]="true"
+        styleClass="p-button-sm cloud-accent-btn text-xxs sm:text-xs"
+        (click)="goToTrash()"
+      ></p-button>
+      <p-button
+        label="Refresh"
+        icon="pi pi-refresh"
+        [outlined]="true"
+        styleClass="p-button-sm cloud-accent-btn text-xxs sm:text-xs"
+        (click)="reloadRootFolder()"
+      ></p-button>
+    </div>
   </section>
 
   <section class="cloud-toolbar-wrap">

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -8,7 +8,7 @@
         {{ totalItemsInView }} items in this folder
       </p>
     </div>
-    <div class="cloud-headline-actions" style="display: flex; gap: 0.5rem">
+    <div class="cloud-headline-actions">
       <p-button
         label="Trash"
         icon="pi pi-trash"

--- a/frontend/src/app/pages/cloud/cloud.component.scss
+++ b/frontend/src/app/pages/cloud/cloud.component.scss
@@ -13,6 +13,11 @@
   margin-bottom: 0.5rem;
 }
 
+.cloud-headline-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .cloud-title {
   margin: 0;
 }

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 import { MenuItem, ConfirmationService } from 'primeng/api';
 import { BreadcrumbModule } from 'primeng/breadcrumb';
 import { ButtonModule } from 'primeng/button';
@@ -91,6 +92,7 @@ export class CloudComponent implements OnInit {
     private cloudService: CloudService,
     private confirmationService: ConfirmationService,
     private toast: UiToastService,
+    private router: Router,
   ) {}
 
   private getErrorMessage(err: unknown): string {
@@ -220,6 +222,10 @@ export class CloudComponent implements OnInit {
 
   reloadRootFolder() {
     this.loadRootFolder();
+  }
+
+  goToTrash() {
+    this.router.navigate(['/cloud/trash']);
   }
 
   navigateToFolder(folderPath?: string) {

--- a/frontend/src/app/pages/cloud/trash/trash.component.html
+++ b/frontend/src/app/pages/cloud/trash/trash.component.html
@@ -70,6 +70,7 @@
               <p-button
                 icon="pi pi-trash"
                 severity="danger"
+                ariaLabel="Delete permanently"
                 styleClass="p-button-rounded p-button-text p-button-sm"
                 [disabled]="isProcessing(entry.id)"
                 (click)="confirmPurge(entry)"

--- a/frontend/src/app/pages/cloud/trash/trash.component.html
+++ b/frontend/src/app/pages/cloud/trash/trash.component.html
@@ -1,0 +1,90 @@
+<div class="trash-shell">
+  <p-confirmdialog></p-confirmdialog>
+
+  <section class="trash-headline">
+    <div>
+      <h1 class="trash-title text-base sm:text-lg">Trash</h1>
+      <p class="trash-subtitle text-xxs sm:text-xs">
+        Deleted files are kept here and removed automatically after 30 days.
+      </p>
+    </div>
+    <div class="trash-headline-actions">
+      <p-button
+        label="Back to Cloud"
+        icon="pi pi-arrow-left"
+        [outlined]="true"
+        styleClass="p-button-sm text-xxs sm:text-xs"
+        (click)="goToCloud()"
+      ></p-button>
+      <p-button
+        label="Refresh"
+        icon="pi pi-refresh"
+        [outlined]="true"
+        styleClass="p-button-sm text-xxs sm:text-xs"
+        (click)="loadTrash()"
+      ></p-button>
+    </div>
+  </section>
+
+  <div *ngIf="loading" class="trash-state text-xxs sm:text-xs">
+    <i class="pi pi-spin pi-spinner"></i>
+    Loading trash...
+  </div>
+
+  <div *ngIf="error" class="trash-state trash-state-error text-xxs sm:text-xs">
+    <i class="pi pi-exclamation-triangle"></i>
+    {{ error }}
+  </div>
+
+  <section *ngIf="!loading && !error" class="trash-table-wrap">
+    <p-table
+      [value]="entries"
+      styleClass="text-xxs sm:text-xs"
+      [tableStyle]="{ 'min-width': '100%' }"
+    >
+      <ng-template pTemplate="header">
+        <tr>
+          <th>Name</th>
+          <th>Original location</th>
+          <th>Deleted</th>
+          <th>Size</th>
+          <th class="text-right">Actions</th>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-entry>
+        <tr>
+          <td>{{ entry.name }}</td>
+          <td class="trash-muted">{{ entry.originalPath }}</td>
+          <td class="trash-muted">{{ entry.deletedAt | date: "medium" }}</td>
+          <td class="trash-muted">{{ formatFileSize(entry.size) }}</td>
+          <td>
+            <div class="trash-actions">
+              <p-button
+                label="Restore"
+                icon="pi pi-replay"
+                styleClass="p-button-text p-button-sm"
+                [loading]="isProcessing(entry.id)"
+                [disabled]="isProcessing(entry.id)"
+                (click)="restore(entry)"
+              ></p-button>
+              <p-button
+                icon="pi pi-trash"
+                severity="danger"
+                styleClass="p-button-rounded p-button-text p-button-sm"
+                [disabled]="isProcessing(entry.id)"
+                (click)="confirmPurge(entry)"
+              ></p-button>
+            </div>
+          </td>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="emptymessage">
+        <tr>
+          <td colspan="5" class="trash-empty text-xxs sm:text-xs">
+            Trash is empty.
+          </td>
+        </tr>
+      </ng-template>
+    </p-table>
+  </section>
+</div>

--- a/frontend/src/app/pages/cloud/trash/trash.component.scss
+++ b/frontend/src/app/pages/cloud/trash/trash.component.scss
@@ -1,0 +1,57 @@
+.trash-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.trash-headline {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.trash-headline-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.trash-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.trash-subtitle {
+  margin: 0.25rem 0 0;
+  opacity: 0.7;
+}
+
+.trash-state {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+}
+
+.trash-state-error {
+  color: var(--red-500, #ef4444);
+}
+
+.trash-actions {
+  display: flex;
+  gap: 0.25rem;
+  justify-content: flex-end;
+}
+
+.trash-muted {
+  opacity: 0.8;
+}
+
+.trash-empty {
+  text-align: center;
+  opacity: 0.7;
+  padding: 1.5rem;
+}

--- a/frontend/src/app/pages/cloud/trash/trash.component.ts
+++ b/frontend/src/app/pages/cloud/trash/trash.component.ts
@@ -120,8 +120,11 @@ export class TrashComponent implements OnInit {
   formatFileSize(bytes: number): string {
     if (bytes === 0) return '0 Bytes';
     const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    const i = Math.min(
+      Math.floor(Math.log(bytes) / Math.log(k)),
+      sizes.length - 1,
+    );
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   }
 

--- a/frontend/src/app/pages/cloud/trash/trash.component.ts
+++ b/frontend/src/app/pages/cloud/trash/trash.component.ts
@@ -1,0 +1,161 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { ConfirmationService } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { TableModule } from 'primeng/table';
+import { finalize } from 'rxjs';
+import { TrashEntryDto } from '../../../models/dtos/TrashEntryDto';
+import { CloudService } from '../../../services/cloud.service';
+import { UiToastService } from '../../../core/services/ui-toast.service';
+
+@Component({
+  selector: 'app-trash',
+  standalone: true,
+  imports: [CommonModule, TableModule, ButtonModule, ConfirmDialogModule],
+  providers: [ConfirmationService],
+  templateUrl: './trash.component.html',
+  styleUrls: ['./trash.component.scss'],
+})
+export class TrashComponent implements OnInit {
+  entries: TrashEntryDto[] = [];
+  loading = true;
+  error?: string;
+  processingIds = new Set<string>();
+
+  constructor(
+    private cloudService: CloudService,
+    private confirmationService: ConfirmationService,
+    private toast: UiToastService,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.loadTrash();
+  }
+
+  loadTrash(): void {
+    this.loading = true;
+    this.error = undefined;
+    this.cloudService.listTrash().subscribe({
+      next: (entries) => {
+        this.entries = entries;
+        this.loading = false;
+      },
+      error: () => {
+        this.error = 'Error loading trash';
+        this.toast.error(
+          'Could not load trash',
+          'Trash contents are unavailable.',
+        );
+        this.loading = false;
+      },
+    });
+  }
+
+  goToCloud(): void {
+    this.router.navigate(['/cloud']);
+  }
+
+  isProcessing(id: string): boolean {
+    return this.processingIds.has(id);
+  }
+
+  restore(entry: TrashEntryDto): void {
+    this.processingIds.add(entry.id);
+    this.cloudService
+      .restoreTrashEntry(entry.id)
+      .pipe(finalize(() => this.processingIds.delete(entry.id)))
+      .subscribe({
+        next: () => {
+          this.entries = this.entries.filter((e) => e.id !== entry.id);
+          this.toast.success(
+            'File restored',
+            `"${entry.name}" was restored to ${entry.originalPath}.`,
+          );
+        },
+        error: (err) => {
+          if (this.isConflict(err)) {
+            this.toast.error(
+              'Restore conflict',
+              `A file already exists at ${entry.originalPath}. Rename or move it, then try again.`,
+            );
+          } else {
+            this.toast.error('Restore failed', this.getErrorMessage(err));
+          }
+        },
+      });
+  }
+
+  confirmPurge(entry: TrashEntryDto): void {
+    this.confirmationService.confirm({
+      header: 'Delete permanently',
+      message: `Permanently delete "${entry.name}"? This cannot be undone.`,
+      icon: 'pi pi-exclamation-triangle',
+      acceptButtonStyleClass: 'p-button-danger p-button-sm',
+      rejectButtonStyleClass: 'p-button-text p-button-sm',
+      accept: () => this.purge(entry),
+    });
+  }
+
+  purge(entry: TrashEntryDto): void {
+    this.processingIds.add(entry.id);
+    this.cloudService
+      .purgeTrashEntry(entry.id)
+      .pipe(finalize(() => this.processingIds.delete(entry.id)))
+      .subscribe({
+        next: () => {
+          this.entries = this.entries.filter((e) => e.id !== entry.id);
+          this.toast.success(
+            'File deleted',
+            `"${entry.name}" was permanently deleted.`,
+          );
+        },
+        error: (err) =>
+          this.toast.error('Delete failed', this.getErrorMessage(err)),
+      });
+  }
+
+  formatFileSize(bytes: number): string {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  }
+
+  // The backend signals a restore collision with FileAlreadyExistsException;
+  // accept either a 409 or the "already exists" message so the UX stays graceful
+  // regardless of how that surfaces.
+  private isConflict(err: unknown): boolean {
+    const candidate = err as {
+      status?: number;
+      error?: unknown;
+      message?: string;
+    };
+    if (candidate?.status === 409) return true;
+    const body =
+      typeof candidate?.error === 'string'
+        ? candidate.error
+        : (candidate?.error as { message?: string })?.message ||
+          candidate?.message ||
+          '';
+    return /already exists/i.test(body);
+  }
+
+  private getErrorMessage(err: unknown): string {
+    const candidate = err as {
+      message?: string;
+      error?: { message?: string } | string;
+    };
+    if (typeof candidate?.error === 'string' && candidate.error.trim()) {
+      return candidate.error;
+    }
+    return (
+      (candidate?.error as { message?: string })?.message ||
+      candidate?.message ||
+      'Request failed. Please try again.'
+    );
+  }
+}

--- a/frontend/src/app/services/cloud.service.ts
+++ b/frontend/src/app/services/cloud.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { FolderDto } from '../models/dtos/FolderDto';
 import { FolderContentItemDto } from '../models/dtos/FolderContentItemDto';
 import { PageResponseDto } from '../models/dtos/PageResponseDto';
+import { TrashEntryDto } from '../models/dtos/TrashEntryDto';
 import { environment } from '../../environments/environment';
 
 @Injectable({
@@ -134,5 +135,22 @@ export class CloudService {
       params: { path },
       responseType: 'blob',
     });
+  }
+
+  listTrash(): Observable<TrashEntryDto[]> {
+    return this.http.get<TrashEntryDto[]>(`${this.apiUrl}/files/trash`);
+  }
+
+  restoreTrashEntry(id: string): Observable<void> {
+    return this.http.post<void>(
+      `${this.apiUrl}/files/trash/${encodeURIComponent(id)}/restore`,
+      null,
+    );
+  }
+
+  purgeTrashEntry(id: string): Observable<void> {
+    return this.http.delete<void>(
+      `${this.apiUrl}/files/trash/${encodeURIComponent(id)}`,
+    );
   }
 }


### PR DESCRIPTION
Closes #237.

Adds the cloud-page trash view that consumes the per-user trash endpoints from Vault-Web/cloud-page#79.

## What's included
- `CloudService` methods for the three endpoints (`GET /files/trash`, `POST /files/trash/{id}/restore`, `DELETE /files/trash/{id}`) plus a `TrashEntryDto` model (`id`, `name`, `originalPath`, `deletedAt`, `size`).
- A standalone `TrashComponent` (route `/cloud/trash`, behind `authGuard`): a table of trashed entries (name, original location, deleted date, size) with **Restore** and **permanent-delete** actions; permanent delete asks for confirmation. Loading / error / empty states included.
- A **Trash** entry point in the cloud toolbar.
- Restore-conflict handling: when a file already exists at the original path, the user gets a clear message instead of a generic failure.

## Notes
- Depends on Vault-Web/cloud-page#79 (the backend trash endpoints) being merged for the endpoints to exist.
- The backend currently surfaces a restore conflict as a 500 (`FileAlreadyExistsException` isn't mapped to 409); the UI handles both that and a future 409, so it degrades gracefully either way. Happy to send a one-line follow-up on cloud-page#79 mapping it to 409 for a cleaner contract.
- Verified locally with `ng build` (AOT + strict templates) and Prettier.
