### PR TITLE
fix: redirect to login on expired session

### DIFF
--- a/frontend/src/app/core/interceptors/token.interceptor.ts
+++ b/frontend/src/app/core/interceptors/token.interceptor.ts
@@ -1,4 +1,9 @@
-import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
+import {
+  HttpErrorResponse,
+  HttpHandlerFn,
+  HttpInterceptorFn,
+  HttpRequest,
+} from '@angular/common/http';
 import { inject } from '@angular/core';
 import { catchError, switchMap, throwError, ReplaySubject } from 'rxjs';
 import { AuthService } from '../../services/auth.service';
@@ -21,11 +26,7 @@ export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
         }
 
         if (error.status === 401) {
-          // If the refresh token request itself fails, we must logout.
-          if (req.url.includes('/refresh')) {
-            authService.logout();
-          }
-          // Otherwise, just pass the 401 through.
+          return handleUnauthorized(req, next, authService, error);
         }
         return throwError(() => error);
       }),
@@ -57,50 +58,58 @@ export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
         return throwError(() => error);
       }
 
-      // If the refresh endpoint returns 401, the refresh token is invalid/expired.
-      if (req.url.includes('/refresh')) {
-        authService.logout();
-        return throwError(() => error);
-      }
-
-      // Handle 401 by attempting to refresh the token
-      if (isRefreshing) {
-        return refreshTokenSubject.pipe(
-          switchMap((token) => {
-            const retryReq = req.clone({
-              setHeaders: { Authorization: `Bearer ${token}` },
-            });
-            return next(retryReq);
-          }),
-        );
-      }
-
-      isRefreshing = true;
-      refreshTokenSubject = new ReplaySubject<string>(1);
-
-      return authService.refresh().pipe(
-        switchMap((res) => {
-          isRefreshing = false;
-          authService.saveToken(res.token);
-          refreshTokenSubject.next(res.token);
-          refreshTokenSubject.complete();
-
-          const retryReq = req.clone({
-            setHeaders: { Authorization: `Bearer ${res.token}` },
-          });
-
-          return next(retryReq);
-        }),
-        catchError((refreshErr) => {
-          isRefreshing = false;
-          refreshTokenSubject.error(refreshErr);
-          authService.logout();
-          return throwError(() => refreshErr);
-        }),
-      );
+      return handleUnauthorized(req, next, authService, error);
     }),
   );
 };
+
+// Consistently handle a 401 for any request: refresh the token once and retry,
+// or clear the session and redirect to /login when the refresh fails. Requests
+// that carried an explicit Authorization header used to fall through here without
+// a refresh or logout, leaving the user on a broken, unauthenticated page.
+function handleUnauthorized(
+  req: HttpRequest<unknown>,
+  next: HttpHandlerFn,
+  authService: AuthService,
+  error: HttpErrorResponse,
+) {
+  // If the refresh endpoint itself returned 401, the refresh token is invalid.
+  if (req.url.includes('/refresh')) {
+    authService.logout();
+    return throwError(() => error);
+  }
+
+  // A refresh is already in flight: wait for it and retry with the new token.
+  if (isRefreshing) {
+    return refreshTokenSubject.pipe(
+      switchMap((token) =>
+        next(req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })),
+      ),
+    );
+  }
+
+  isRefreshing = true;
+  refreshTokenSubject = new ReplaySubject<string>(1);
+
+  return authService.refresh().pipe(
+    switchMap((res) => {
+      isRefreshing = false;
+      authService.saveToken(res.token);
+      refreshTokenSubject.next(res.token);
+      refreshTokenSubject.complete();
+
+      return next(
+        req.clone({ setHeaders: { Authorization: `Bearer ${res.token}` } }),
+      );
+    }),
+    catchError((refreshErr) => {
+      isRefreshing = false;
+      refreshTokenSubject.error(refreshErr);
+      authService.logout();
+      return throwError(() => refreshErr);
+    }),
+  );
+}
 
 function isBackendUnavailable(error: HttpErrorResponse): boolean {
   return error.status === 0;

--- a/frontend/src/app/core/interceptors/token.interceptor.ts
+++ b/frontend/src/app/core/interceptors/token.interceptor.ts
@@ -74,7 +74,7 @@ function handleUnauthorized(
   error: HttpErrorResponse,
 ) {
   // If the refresh endpoint itself returned 401, the refresh token is invalid.
-  if (req.url.includes('/refresh')) {
+  if (req.url.includes('/auth/refresh')) {
     authService.logout();
     return throwError(() => error);
   }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -75,7 +75,38 @@ export class AuthService {
   }
 
   isLoggedIn(): boolean {
-    return !!localStorage.getItem('token');
+    const token = localStorage.getItem('token');
+    return !!token && !this.isTokenExpired(token);
+  }
+
+  // A present-but-expired token must not count as logged in, otherwise authGuard
+  // would let a stale session navigate to protected pages. If the token can't be
+  // decoded we fall back to "not expired" and let the 401 + refresh flow handle
+  // it, to avoid logging the user out on a parsing quirk.
+  private isTokenExpired(token: string): boolean {
+    const expiryMs = this.getTokenExpiryMs(token);
+    return expiryMs !== null && Date.now() >= expiryMs;
+  }
+
+  private getTokenExpiryMs(token: string): number | null {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return null;
+    }
+    try {
+      const payload = JSON.parse(this.decodeBase64Url(parts[1])) as {
+        exp?: number;
+      };
+      return typeof payload.exp === 'number' ? payload.exp * 1000 : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private decodeBase64Url(value: string): string {
+    const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = (4 - (base64.length % 4)) % 4;
+    return atob(base64 + '='.repeat(padding));
   }
 
   logout(): void {

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -76,37 +76,42 @@ export class AuthService {
 
   isLoggedIn(): boolean {
     const token = localStorage.getItem('token');
-    return !!token && !this.isTokenExpired(token);
+    if (!token) {
+      return false;
+    }
+    const payload = this.decodeTokenPayload(token);
+    // A token we cannot decode is treated as logged-out (fail closed), so a stale or
+    // malformed token never grants navigation to protected pages. A valid token with no
+    // `exp` claim never expires and stays logged in; otherwise it must not be past expiry.
+    if (payload === null) {
+      return false;
+    }
+    if (typeof payload.exp !== 'number') {
+      return true;
+    }
+    return Date.now() < payload.exp * 1000;
   }
 
-  // A present-but-expired token must not count as logged in, otherwise authGuard
-  // would let a stale session navigate to protected pages. If the token can't be
-  // decoded we fall back to "not expired" and let the 401 + refresh flow handle
-  // it, to avoid logging the user out on a parsing quirk.
-  private isTokenExpired(token: string): boolean {
-    const expiryMs = this.getTokenExpiryMs(token);
-    return expiryMs !== null && Date.now() >= expiryMs;
-  }
-
-  private getTokenExpiryMs(token: string): number | null {
+  private decodeTokenPayload(token: string): { exp?: number } | null {
     const parts = token.split('.');
     if (parts.length !== 3) {
       return null;
     }
     try {
-      const payload = JSON.parse(this.decodeBase64Url(parts[1])) as {
-        exp?: number;
-      };
-      return typeof payload.exp === 'number' ? payload.exp * 1000 : null;
+      return JSON.parse(this.decodeBase64Url(parts[1])) as { exp?: number };
     } catch {
       return null;
     }
   }
 
+  // JWT payloads are base64url-encoded UTF-8; decode to bytes and run them through
+  // TextDecoder so non-ASCII claims don't corrupt the parse.
   private decodeBase64Url(value: string): string {
     const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
-    const padding = (4 - (base64.length % 4)) % 4;
-    return atob(base64 + '='.repeat(padding));
+    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder('utf-8').decode(bytes);
   }
 
   logout(): void {


### PR DESCRIPTION
Closes #232.

An expired session now consistently returns the user to login instead of leaving them on a broken, unauthenticated page:

- `isLoggedIn()` decodes the JWT `exp`, so `authGuard` treats a present-but-expired token as logged out and redirects.
- The token interceptor now handles `401`s the same way on both paths — a request that already carries an `Authorization` header also refreshes-and-retries once, or clears the session and redirects when the refresh fails (previously it passed the `401` through untouched). Since every `401` now flows through this path, components no longer get stuck showing a local error without the global logout firing.

Verified locally with `ng build` (AOT + strict templates) and Prettier.
