### PR TITLE
feat: add sorting controls to the cloud page

### DIFF
--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -35,7 +35,7 @@
             icon="pi pi-plus"
             [outlined]="true"
             styleClass="p-button-sm cloud-accent-btn text-xxs sm:text-xs"
-            (click)="toggleCreateMenu($event, createMenu)"
+            (click)="toggleMenu($event, createMenu)"
           ></p-button>
           <p-menu
             #createMenu
@@ -48,7 +48,7 @@
             icon="pi pi-sort-alt"
             [outlined]="true"
             styleClass="p-button-sm cloud-accent-btn text-xxs sm:text-xs"
-            (click)="toggleCreateMenu($event, sortMenu)"
+            (click)="toggleMenu($event, sortMenu)"
           ></p-button>
           <p-menu
             #sortMenu

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -43,6 +43,19 @@
             [appendTo]="'body'"
             [model]="createMenuItems"
           ></p-menu>
+          <p-button
+            label="Sort"
+            icon="pi pi-sort-alt"
+            [outlined]="true"
+            styleClass="p-button-sm cloud-accent-btn text-xxs sm:text-xs"
+            (click)="toggleCreateMenu($event, sortMenu)"
+          ></p-button>
+          <p-menu
+            #sortMenu
+            [popup]="true"
+            [appendTo]="'body'"
+            [model]="sortMenuItems"
+          ></p-menu>
           <input
             #fileUploadInput
             type="file"

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -76,6 +76,8 @@ export class CloudComponent implements OnInit {
   selectedFileForRename: FileDto | null = null;
 
   createMenuItems: MenuItem[] = [];
+  sortMenuItems: MenuItem[] = [];
+  sort = 'name,asc';
   entries: CloudEntry[] = [];
   downloadingPaths = new Set<string>();
 
@@ -125,6 +127,38 @@ export class CloudComponent implements OnInit {
         command: () => this.openFileUploadDialog(),
       },
     ];
+    this.sortMenuItems = [
+      {
+        label: 'Name (A–Z)',
+        icon: 'pi pi-sort-alpha-down',
+        command: () => this.setSort('name,asc'),
+      },
+      {
+        label: 'Name (Z–A)',
+        icon: 'pi pi-sort-alpha-up-alt',
+        command: () => this.setSort('name,desc'),
+      },
+      {
+        label: 'Newest first',
+        icon: 'pi pi-sort-amount-down',
+        command: () => this.setSort('lastModifiedAt,desc'),
+      },
+      {
+        label: 'Oldest first',
+        icon: 'pi pi-sort-amount-up',
+        command: () => this.setSort('lastModifiedAt,asc'),
+      },
+      {
+        label: 'Largest first',
+        icon: 'pi pi-sort-amount-down',
+        command: () => this.setSort('size,desc'),
+      },
+      {
+        label: 'Smallest first',
+        icon: 'pi pi-sort-amount-up',
+        command: () => this.setSort('size,asc'),
+      },
+    ];
     this.loadRootFolder();
   }
 
@@ -161,7 +195,7 @@ export class CloudComponent implements OnInit {
     // quickly, an earlier (slower) request must not overwrite newer state.
     const requestId = ++this.contentRequestId;
     this.cloudService
-      .getFolderContent(relativePath, page, this.pageSize)
+      .getFolderContent(relativePath, page, this.pageSize, this.sort)
       .subscribe({
         next: (contentPage) => {
           if (requestId !== this.contentRequestId) return;
@@ -196,6 +230,17 @@ export class CloudComponent implements OnInit {
       this.currentFolder?.path || this.rootPath,
     );
     this.loadFolderContent(relativePath, page);
+  }
+
+  setSort(sort: string) {
+    if (this.sort === sort) return;
+    this.sort = sort;
+    this.contentFirst = 0;
+    this.loading = true;
+    const relativePath = this.getRelativePath(
+      this.currentFolder?.path || this.rootPath,
+    );
+    this.loadFolderContent(relativePath, 0);
   }
 
   loadRootFolder() {

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -32,6 +32,14 @@ interface CloudEntry {
   typeLabel: string;
 }
 
+type CloudSort =
+  | 'name,asc'
+  | 'name,desc'
+  | 'lastModifiedAt,asc'
+  | 'lastModifiedAt,desc'
+  | 'size,asc'
+  | 'size,desc';
+
 @Component({
   selector: 'app-cloud',
   standalone: true,
@@ -77,7 +85,7 @@ export class CloudComponent implements OnInit {
 
   createMenuItems: MenuItem[] = [];
   sortMenuItems: MenuItem[] = [];
-  sort = 'name,asc';
+  sort: CloudSort = 'name,asc';
   entries: CloudEntry[] = [];
   downloadingPaths = new Set<string>();
 
@@ -232,7 +240,7 @@ export class CloudComponent implements OnInit {
     this.loadFolderContent(relativePath, page);
   }
 
-  setSort(sort: string) {
+  setSort(sort: CloudSort) {
     if (this.sort === sort) return;
     this.sort = sort;
     this.contentFirst = 0;
@@ -340,7 +348,7 @@ export class CloudComponent implements OnInit {
     return relative || '/';
   }
 
-  toggleCreateMenu(event: Event, menu: Menu) {
+  toggleMenu(event: Event, menu: Menu) {
     menu.toggle(event);
   }
 


### PR DESCRIPTION
Closes #213.

Adds a **Sort** menu to the cloud toolbar with Name (A–Z / Z–A), Newest / Oldest and Largest / Smallest. The chosen order is sent to the folder-content endpoint and persists while navigating between folders.

The server side already accepted a `sort` parameter but only ordered by name; sorting by `size` and `lastModifiedAt` is added in Vault-Web/cloud-page#82. This PR is the UI half.

Verified with `ng build` (AOT + strict templates) and Prettier.
