### PR TITLE
fix: pin JVM default timezone to UTC to prevent Postgres handshake failure

### DIFF
--- a/backend/src/main/java/vaultWeb/BackendApplication.java
+++ b/backend/src/main/java/vaultWeb/BackendApplication.java
@@ -1,5 +1,6 @@
 package vaultWeb;
 
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -35,6 +36,17 @@ public class BackendApplication implements WebMvcConfigurer {
    * @param args Command-line arguments passed to the application.
    */
   public static void main(String[] args) {
+    pinDefaultTimeZone();
     SpringApplication.run(BackendApplication.class, args);
+  }
+
+  // The PostgreSQL driver sends the JVM's default timezone id during the JDBC handshake, before
+  // Hibernate's hibernate.jdbc.time_zone setting ever applies. On JDKs whose tzdata resolves to a
+  // deprecated alias (e.g. "Asia/Calcutta" instead of "Asia/Kolkata"), recent PostgreSQL versions
+  // reject that value outright and the app fails to start. Pinning the default here removes the
+  // dependency on the host's tzdata.
+  static void pinDefaultTimeZone() {
+    String timeZoneId = System.getenv().getOrDefault("APP_TIMEZONE", "UTC");
+    TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId));
   }
 }

--- a/backend/src/test/java/vaultWeb/BackendApplicationTimeZoneTest.java
+++ b/backend/src/test/java/vaultWeb/BackendApplicationTimeZoneTest.java
@@ -1,0 +1,32 @@
+package vaultWeb;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.TimeZone;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BackendApplicationTimeZoneTest {
+
+  private TimeZone originalDefault;
+
+  @BeforeEach
+  void captureOriginalTimeZone() {
+    originalDefault = TimeZone.getDefault();
+  }
+
+  @AfterEach
+  void restoreOriginalTimeZone() {
+    TimeZone.setDefault(originalDefault);
+  }
+
+  @Test
+  void pinsJvmDefaultTimeZoneToUtcWhenNoOverrideIsConfigured() {
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Calcutta"));
+
+    BackendApplication.pinDefaultTimeZone();
+
+    assertEquals(TimeZone.getTimeZone("UTC"), TimeZone.getDefault());
+  }
+}

--- a/common_problems.md
+++ b/common_problems.md
@@ -49,9 +49,15 @@ JDBC metadata, causing cascading startup failures.
 
 ### Solution
 
-Avoid relying on JVM default timezone values at startup.
+As of this fix, the backend pins the JVM default timezone to **UTC** itself at startup
+(`BackendApplication.pinDefaultTimeZone()`), before any JDBC connection is opened. This removes
+the dependency on the host's tzdata, so the error above should no longer occur regardless of how
+the backend is launched (`mvnw`, IDE run config, packaged jar).
 
-**Option 1: Explicitly set JVM timezone (recommended)**
+If you still hit this (e.g. on an older checkout, or after pulling without rebuilding), the manual
+workarounds below still apply:
+
+**Option 1: Explicitly set JVM timezone**
 
 Pass a valid timezone identifier via JVM arguments. Using **UTC** is the safest way to ensure consistency across environments.
 
@@ -75,6 +81,9 @@ Asia/Kolkata
 UTC
 ```
 Then restart the backend.
+
+**Need a non-UTC default?** Set the `APP_TIMEZONE` environment variable (e.g. `APP_TIMEZONE=Asia/Kolkata`).
+It is honored both by `pinDefaultTimeZone()` and by `hibernate.jdbc.time_zone`, so the two stay in sync.
 
 ---
 


### PR DESCRIPTION
## Summary
- Backend startup crashes with `FATAL: invalid value for parameter "TimeZone": "Asia/Calcutta"` on JDK/OS combos whose tzdata resolves to a deprecated timezone alias.
- Root cause (confirmed in the issue thread): the pgjdbc driver sends the JVM's default timezone during the connection handshake, before `hibernate.jdbc.time_zone` ever applies, so recent PostgreSQL versions reject the deprecated alias outright.
- Fix: pin the JVM default timezone to UTC in `BackendApplication.main()`, before any JDBC connection is opened. Overridable via the existing `APP_TIMEZONE` env var so it stays in sync with `hibernate.jdbc.time_zone`.
- Updated `common_problems.md` to reflect that this is now handled automatically, keeping the manual `-Duser.timezone=UTC` workaround as a fallback.

Fixes #243

## Test plan
- [x] Added `BackendApplicationTimeZoneTest` verifying the JVM default timezone is pinned to UTC.
- [x] Ran full backend suite in a Java 21 container (local JDK is 20): `BUILD SUCCESS`, 155 tests run, 0 failures, 0 errors.