### PR TITLE
feat: add drag and drop support for moving files and folders #210

### DIFF
--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -138,6 +138,7 @@
               (dragstart)="
                 onDragStart($event, entry.path, entry.kind === 'folder')
               "
+              (dragend)="onDragEnd()"
               (click)="
                 entry.kind === 'folder'
                   ? navigateToFolder(entry.path)

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -80,7 +80,9 @@
               (click)="item.command ? item.command() : null"
             >
               <span *ngIf="item.icon" [class]="item.icon"></span>
-              <span *ngIf="item.label" class="p-menuitem-text">{{ item.label }}</span>
+              <span *ngIf="item.label" class="p-menuitem-text">{{
+                item.label
+              }}</span>
             </a>
           </ng-template>
         </p-breadcrumb>
@@ -121,7 +123,9 @@
       <ng-template pTemplate="body" let-entry>
         <tr
           class="cloud-row"
-          [class.drag-over]="entry.kind === 'folder' && draggedOverPath === entry.path"
+          [class.drag-over]="
+            entry.kind === 'folder' && draggedOverPath === entry.path
+          "
           (drop)="onDrop($event, entry.kind === 'folder' ? entry.path : null)"
           (dragover)="onDragOver($event, entry.path, entry.kind === 'folder')"
           (dragleave)="onDragLeave()"

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -21,7 +21,7 @@
         icon="pi pi-refresh"
         [outlined]="true"
         styleClass="p-button-sm cloud-accent-btn text-xxs sm:text-xs"
-        (click)="reloadRootFolder()"
+        (click)="reloadCurrentFolder()"
       ></p-button>
     </div>
   </section>
@@ -69,7 +69,21 @@
           [model]="breadcrumbItems"
           [home]="homeBreadcrumb"
           styleClass="cloud-breadcrumb text-xxs sm:text-xs"
-        ></p-breadcrumb>
+        >
+          <ng-template pTemplate="item" let-item>
+            <a
+              class="p-menuitem-link cursor-pointer"
+              [class.drag-over]="draggedOverPath === item.id"
+              (drop)="onBreadcrumbDrop($event, item.id)"
+              (dragover)="onBreadcrumbDragOver($event, item.id)"
+              (dragleave)="onDragLeave()"
+              (click)="item.command ? item.command() : null"
+            >
+              <span *ngIf="item.icon" [class]="item.icon"></span>
+              <span *ngIf="item.label" class="p-menuitem-text">{{ item.label }}</span>
+            </a>
+          </ng-template>
+        </p-breadcrumb>
       </ng-template>
     </p-toolbar>
   </section>
@@ -107,8 +121,10 @@
       <ng-template pTemplate="body" let-entry>
         <tr
           class="cloud-row"
+          [class.drag-over]="entry.kind === 'folder' && draggedOverPath === entry.path"
           (drop)="onDrop($event, entry.kind === 'folder' ? entry.path : null)"
-          (dragover)="onDragOver($event)"
+          (dragover)="onDragOver($event, entry.path, entry.kind === 'folder')"
+          (dragleave)="onDragLeave()"
         >
           <td>
             <button

--- a/frontend/src/app/pages/cloud/cloud.component.scss
+++ b/frontend/src/app/pages/cloud/cloud.component.scss
@@ -69,8 +69,17 @@
   font-weight: 600;
 }
 
-:host ::ng-deep .cloud-breadcrumb .p-breadcrumb-list li .p-menuitem-link.drag-over {
-  background: color-mix(in srgb, var(--color-primary) 15%, transparent) !important;
+:host
+  ::ng-deep
+  .cloud-breadcrumb
+  .p-breadcrumb-list
+  li
+  .p-menuitem-link.drag-over {
+  background: color-mix(
+    in srgb,
+    var(--color-primary) 15%,
+    transparent
+  ) !important;
   outline: 1px dashed var(--color-primary);
   border-radius: 4px;
   padding: 2px 4px;
@@ -127,7 +136,11 @@
 }
 
 .cloud-row.drag-over {
-  background: color-mix(in srgb, var(--color-primary) 15%, var(--color-surface)) !important;
+  background: color-mix(
+    in srgb,
+    var(--color-primary) 15%,
+    var(--color-surface)
+  ) !important;
   outline: 2px dashed var(--color-primary);
   outline-offset: -2px;
 }

--- a/frontend/src/app/pages/cloud/cloud.component.scss
+++ b/frontend/src/app/pages/cloud/cloud.component.scss
@@ -69,6 +69,13 @@
   font-weight: 600;
 }
 
+:host ::ng-deep .cloud-breadcrumb .p-breadcrumb-list li .p-menuitem-link.drag-over {
+  background: color-mix(in srgb, var(--color-primary) 15%, transparent) !important;
+  outline: 1px dashed var(--color-primary);
+  border-radius: 4px;
+  padding: 2px 4px;
+}
+
 .cloud-state {
   display: inline-flex;
   align-items: center;
@@ -117,6 +124,12 @@
 
 .cloud-row {
   transition: background-color 0.2s ease;
+}
+
+.cloud-row.drag-over {
+  background: color-mix(in srgb, var(--color-primary) 15%, var(--color-surface)) !important;
+  outline: 2px dashed var(--color-primary);
+  outline-offset: -2px;
 }
 
 .cloud-entry-btn {

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -694,7 +694,11 @@ export class CloudComponent implements OnInit {
     }
   }
 
-  isInvalidMove(sourcePath: string, targetPath: string, isFolder: boolean): boolean {
+  isInvalidMove(
+    sourcePath: string,
+    targetPath: string,
+    isFolder: boolean,
+  ): boolean {
     const relativeSource = this.getRelativePath(sourcePath);
     const relativeTarget = this.getRelativePath(targetPath);
 
@@ -722,7 +726,10 @@ export class CloudComponent implements OnInit {
   onDragOver(event: DragEvent, path: string, isFolder: boolean) {
     if (!this.draggedPath) return;
 
-    if (isFolder && !this.isInvalidMove(this.draggedPath, path, this.draggedIsFolder)) {
+    if (
+      isFolder &&
+      !this.isInvalidMove(this.draggedPath, path, this.draggedIsFolder)
+    ) {
       event.preventDefault();
       if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
       this.draggedOverPath = path;
@@ -741,9 +748,21 @@ export class CloudComponent implements OnInit {
     const targetPath = targetFolderPath || this.currentFolder?.path;
     if (!targetPath) return;
 
-    if (this.isInvalidMove(this.draggedPath, targetPath, this.draggedIsFolder)) {
-      if (this.draggedIsFolder && (this.getRelativePath(targetPath) === this.getRelativePath(this.draggedPath) || this.getRelativePath(targetPath).startsWith(this.getRelativePath(this.draggedPath) + '/'))) {
-        this.toast.error('Invalid move', 'Cannot move a folder into itself or its own subfolder.');
+    if (
+      this.isInvalidMove(this.draggedPath, targetPath, this.draggedIsFolder)
+    ) {
+      if (
+        this.draggedIsFolder &&
+        (this.getRelativePath(targetPath) ===
+          this.getRelativePath(this.draggedPath) ||
+          this.getRelativePath(targetPath).startsWith(
+            this.getRelativePath(this.draggedPath) + '/',
+          ))
+      ) {
+        this.toast.error(
+          'Invalid move',
+          'Cannot move a folder into itself or its own subfolder.',
+        );
       }
       this.draggedPath = null;
       return;
@@ -757,15 +776,21 @@ export class CloudComponent implements OnInit {
         await firstValueFrom(
           this.cloudService.renameOrMoveFolder(
             relativeSource,
-            this.joinRelativePath(relativeTarget, this.getNameFromPath(this.draggedPath)),
-          )
+            this.joinRelativePath(
+              relativeTarget,
+              this.getNameFromPath(this.draggedPath),
+            ),
+          ),
         );
       } else {
         await firstValueFrom(
           this.cloudService.renameOrMoveFile(
             relativeSource,
-            this.joinRelativePath(relativeTarget, this.getNameFromPath(this.draggedPath)),
-          )
+            this.joinRelativePath(
+              relativeTarget,
+              this.getNameFromPath(this.draggedPath),
+            ),
+          ),
         );
       }
       this.reloadCurrentFolder();
@@ -792,7 +817,9 @@ export class CloudComponent implements OnInit {
     this.draggedOverPath = null;
     if (!this.draggedPath || !targetPath) return;
 
-    if (this.isInvalidMove(this.draggedPath, targetPath, this.draggedIsFolder)) {
+    if (
+      this.isInvalidMove(this.draggedPath, targetPath, this.draggedIsFolder)
+    ) {
       this.draggedPath = null;
       return;
     }
@@ -805,15 +832,21 @@ export class CloudComponent implements OnInit {
         await firstValueFrom(
           this.cloudService.renameOrMoveFolder(
             relativeSource,
-            this.joinRelativePath(relativeTarget, this.getNameFromPath(this.draggedPath)),
-          )
+            this.joinRelativePath(
+              relativeTarget,
+              this.getNameFromPath(this.draggedPath),
+            ),
+          ),
         );
       } else {
         await firstValueFrom(
           this.cloudService.renameOrMoveFile(
             relativeSource,
-            this.joinRelativePath(relativeTarget, this.getNameFromPath(this.draggedPath)),
-          )
+            this.joinRelativePath(
+              relativeTarget,
+              this.getNameFromPath(this.draggedPath),
+            ),
+          ),
         );
       }
       this.reloadCurrentFolder();

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -740,6 +740,11 @@ export class CloudComponent implements OnInit {
     this.draggedOverPath = null;
   }
 
+  onDragEnd() {
+    this.draggedPath = null;
+    this.draggedOverPath = null;
+  }
+
   async onDrop(event: DragEvent, targetFolderPath?: string | null) {
     event.preventDefault();
     this.draggedOverPath = null;

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -97,6 +97,7 @@ export class CloudComponent implements OnInit {
 
   private draggedPath: string | null = null;
   private draggedIsFolder = false;
+  draggedOverPath: string | null = null;
 
   constructor(
     private cloudService: CloudService,
@@ -173,6 +174,7 @@ export class CloudComponent implements OnInit {
   get breadcrumbItems(): MenuItem[] {
     return this.breadcrumbs.map((crumb) => ({
       label: crumb.name,
+      id: crumb.path,
       command: () => this.navigateToFolder(crumb.path),
     }));
   }
@@ -180,6 +182,7 @@ export class CloudComponent implements OnInit {
   get homeBreadcrumb(): MenuItem {
     return {
       icon: 'pi pi-home',
+      id: this.rootPath,
       command: () => this.navigateToRoot(),
     };
   }
@@ -691,38 +694,81 @@ export class CloudComponent implements OnInit {
     }
   }
 
-  onDragOver(event: DragEvent) {
-    event.preventDefault();
-    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+  isInvalidMove(sourcePath: string, targetPath: string, isFolder: boolean): boolean {
+    const relativeSource = this.getRelativePath(sourcePath);
+    const relativeTarget = this.getRelativePath(targetPath);
+
+    // Cannot move to the exact same path
+    if (relativeSource === relativeTarget) {
+      return true;
+    }
+
+    // Cannot move a folder into its own subfolder
+    if (isFolder) {
+      if (relativeTarget.startsWith(relativeSource + '/')) {
+        return true;
+      }
+    }
+
+    // Cannot move an item to its current parent folder (it's already there)
+    const currentParent = this.getParentRelativePath(sourcePath);
+    if (currentParent === relativeTarget) {
+      return true;
+    }
+
+    return false;
+  }
+
+  onDragOver(event: DragEvent, path: string, isFolder: boolean) {
+    if (!this.draggedPath) return;
+
+    if (isFolder && !this.isInvalidMove(this.draggedPath, path, this.draggedIsFolder)) {
+      event.preventDefault();
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+      this.draggedOverPath = path;
+    }
+  }
+
+  onDragLeave() {
+    this.draggedOverPath = null;
   }
 
   async onDrop(event: DragEvent, targetFolderPath?: string | null) {
     event.preventDefault();
+    this.draggedOverPath = null;
     if (!this.draggedPath) return;
 
     const targetPath = targetFolderPath || this.currentFolder?.path;
-    if (!targetPath || this.draggedPath === targetPath) return;
+    if (!targetPath) return;
+
+    if (this.isInvalidMove(this.draggedPath, targetPath, this.draggedIsFolder)) {
+      if (this.draggedIsFolder && (this.getRelativePath(targetPath) === this.getRelativePath(this.draggedPath) || this.getRelativePath(targetPath).startsWith(this.getRelativePath(this.draggedPath) + '/'))) {
+        this.toast.error('Invalid move', 'Cannot move a folder into itself or its own subfolder.');
+      }
+      this.draggedPath = null;
+      return;
+    }
 
     const relativeSource = this.getRelativePath(this.draggedPath);
     const relativeTarget = this.getRelativePath(targetPath);
 
     try {
       if (this.draggedIsFolder) {
-        await this.cloudService
-          .renameOrMoveFolder(
+        await firstValueFrom(
+          this.cloudService.renameOrMoveFolder(
             relativeSource,
-            `${relativeTarget}/${this.getNameFromPath(this.draggedPath)}`,
+            this.joinRelativePath(relativeTarget, this.getNameFromPath(this.draggedPath)),
           )
-          .toPromise();
+        );
       } else {
-        await this.cloudService
-          .renameOrMoveFile(
+        await firstValueFrom(
+          this.cloudService.renameOrMoveFile(
             relativeSource,
-            `${relativeTarget}/${this.getNameFromPath(this.draggedPath)}`,
+            this.joinRelativePath(relativeTarget, this.getNameFromPath(this.draggedPath)),
           )
-          .toPromise();
+        );
       }
-      this.reloadRootFolder();
+      this.reloadCurrentFolder();
       this.toast.success('Item moved', 'Move completed successfully.');
     } catch (err: unknown) {
       this.toast.error('Move failed', this.getErrorMessage(err));
@@ -731,34 +777,46 @@ export class CloudComponent implements OnInit {
     }
   }
 
-  onBreadcrumbDragOver(event: DragEvent) {
-    event.preventDefault();
+  onBreadcrumbDragOver(event: DragEvent, path?: string) {
+    if (!this.draggedPath || !path) return;
+
+    if (!this.isInvalidMove(this.draggedPath, path, this.draggedIsFolder)) {
+      event.preventDefault();
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+      this.draggedOverPath = path;
+    }
   }
 
-  async onBreadcrumbDrop(event: DragEvent, targetPath: string) {
+  async onBreadcrumbDrop(event: DragEvent, targetPath?: string) {
     event.preventDefault();
-    if (!this.draggedPath) return;
+    this.draggedOverPath = null;
+    if (!this.draggedPath || !targetPath) return;
+
+    if (this.isInvalidMove(this.draggedPath, targetPath, this.draggedIsFolder)) {
+      this.draggedPath = null;
+      return;
+    }
 
     const relativeSource = this.getRelativePath(this.draggedPath);
     const relativeTarget = this.getRelativePath(targetPath);
 
     try {
       if (this.draggedIsFolder) {
-        await this.cloudService
-          .renameOrMoveFolder(
+        await firstValueFrom(
+          this.cloudService.renameOrMoveFolder(
             relativeSource,
-            `${relativeTarget}/${this.getNameFromPath(this.draggedPath)}`,
+            this.joinRelativePath(relativeTarget, this.getNameFromPath(this.draggedPath)),
           )
-          .toPromise();
+        );
       } else {
-        await this.cloudService
-          .renameOrMoveFile(
+        await firstValueFrom(
+          this.cloudService.renameOrMoveFile(
             relativeSource,
-            `${relativeTarget}/${this.getNameFromPath(this.draggedPath)}`,
+            this.joinRelativePath(relativeTarget, this.getNameFromPath(this.draggedPath)),
           )
-          .toPromise();
+        );
       }
-      this.reloadRootFolder();
+      this.reloadCurrentFolder();
       this.toast.success('Item moved', 'Move completed successfully.');
     } catch (err: unknown) {
       this.toast.error('Move failed', this.getErrorMessage(err));
@@ -768,8 +826,17 @@ export class CloudComponent implements OnInit {
   }
 
   getNameFromPath(path: string): string {
-    const parts = path.split('/');
+    const normalized = path.replace(/\\/g, '/');
+    const parts = normalized.split('/');
     return parts[parts.length - 1];
+  }
+
+  reloadCurrentFolder() {
+    if (this.currentFolder) {
+      this.navigateToFolder(this.currentFolder.path);
+    } else {
+      this.loadRootFolder();
+    }
   }
 
   previewFile(file: FileDto) {


### PR DESCRIPTION
### Summary
This PR implements comprehensive drag-and-drop support for moving files and folders in the Cloud Page frontend, resolving #210. 

### Key Features Implemented:
1. **Drag-and-Drop Interaction**:
   - Users can drag files and folders by clicking and dragging their name/icon buttons.
   - Folder rows serve as drop targets to move items inside them.
2. **Move Validation & Error Prevention**:
   - Added robust validation to prevent invalid operations:
     - Prevents moving a folder into itself.
     - Prevents moving a folder into its own subfolders.
     - Silently ignores dropping an item into its current directory (preventing redundant API requests).
3. **Breadcrumb Navigation Drop Zones**:
   - Customized the PrimeNG `p-breadcrumb` component to act as drop zones. Users can drag files/folders out of the current directory and drop them onto parent breadcrumbs (including the Home icon).
4. **Visual Highlight Feedback**:
   - Added visual cues (`dashed` borders and background tints) on valid folder rows and breadcrumb targets when dragging over them to indicate where files can be dropped.
5. **Backend Integration**:
   - Fully integrated with `renameOrMoveFile` and `renameOrMoveFolder` APIs.
   - Upgraded legacy `.toPromise()` calls to modern RxJS `firstValueFrom` observables.
6. **Smart Refresh**:
   - The UI now refreshes the current folder view in-place upon a successful move, preserving the user's navigation context.

### Verification & Testing
- Built the frontend successfully (`npm run build`) with no compilation or TypeScript errors.
- Handled all edge cases (moving folders into subfolders, moving files to parent folders via breadcrumbs).
