### PR TITLE
fix: keep chat composer visible when mobile keyboard opens

### DIFF
--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
@@ -1,4 +1,4 @@
-<div class="chat-shell fixed top-0 left-0 w-screen h-screen flex flex-col z-50">
+<div class="chat-shell fixed top-0 left-0 w-screen h-dvh flex flex-col z-50">
   <!-- Header -->
   <div
     class="chat-header px-4 py-3 border-b font-semibold flex justify-between items-center"

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -4,7 +4,10 @@
     <meta charset="utf-8" />
     <title>Vault-Web</title>
     <base href="/" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, interactive-widget=resizes-content"
+    />
     <link rel="icon" type="image/x-icon" href="logo.png" />
     <script src="runtime-config.local.js"></script>
   </head>


### PR DESCRIPTION
## Summary
- The private chat overlay sized itself with `h-screen` (`100vh`), which tracks the static layout viewport and does not shrink when a mobile on-screen keyboard opens. Since the message list and input row are flex siblings inside a `position: fixed` shell, the input row got pushed below the visible area with no way to scroll it into view.
- Switched to `h-dvh` so the shell tracks the dynamic viewport.
- Added `interactive-widget=resizes-content` to the viewport `<meta>` tag so Chromium-based browsers shrink the layout viewport (and therefore `dvh`) when the keyboard appears, instead of leaving it covered.

Fixes #214

## Test plan
- [x] `ng build --configuration production` succeeds; confirmed compiled CSS contains `.h-dvh{height:100dvh}`
- [x] `eslint` clean on changed files
- [ ] Manual check on a real mobile device / Chrome DevTools device toolbar with keyboard open across a couple of viewport sizes and orientations
