### PR TITLE
Added select and upload multiple files at once feature

### DIFF
--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -58,6 +58,7 @@
           ></p-menu>
           <input
             #fileUploadInput
+            multiple
             type="file"
             class="hidden"
             (change)="onFileSelected($event)"

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -489,11 +489,16 @@ export class CloudComponent implements OnInit {
 
   onFileSelected(event: Event) {
     const input = event.target as HTMLInputElement;
-    const file = input?.files?.[0];
-    if (!file) return;
+    const files = input?.files;
+
+    if (!files || files.length === 0) return;
 
     const currentPath = this.getRelativePath(this.currentFolder?.path || '/');
-    this.uploadFile(currentPath, file);
+
+    for (const file of Array.from(files)) {
+      this.uploadFile(currentPath, file);
+    }
+
     input.value = '';
   }
 


### PR DESCRIPTION
## Summary

* Added support for selecting multiple files during upload.
* Updated the file input to allow multiple file selection using the `multiple` attribute.
* Modified `onFileSelected()` to iterate through all selected files and upload each one.
* Preserved the existing upload flow while enabling batch uploads.

#227 

Closes #<issue-number>

## How to test

1. Open the Cloud Page application.
2. Click the **Upload** button.
3. Select multiple files from the file picker.
4. Verify that all selected files are uploaded successfully.
5. Confirm that all uploaded files are displayed in the current folder.
6. Verify that selecting a single file still works as expected.

## Notes / Risk

* Existing single-file upload functionality remains unchanged.
* Files are uploaded individually using the existing upload mechanism, minimizing the impact on the backend.
* No database or API changes required.

<img width="1413" height="843" alt="Screenshot 2026-06-27 at 5 42 33 PM" src="https://github.com/user-attachments/assets/4b84a76c-a059-4f9f-87ac-976e192176fb" />
