### PR TITLE
fix(cloud): prevent layout overflow on mobile viewports

### DIFF
--- a/frontend/src/app/pages/cloud/cloud.component.scss
+++ b/frontend/src/app/pages/cloud/cloud.component.scss
@@ -145,7 +145,8 @@
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   box-shadow: 0 6px 14px -14px var(--color-shadow-md);
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 :host ::ng-deep .cloud-table .p-datatable-table {
@@ -341,5 +342,33 @@
 
   .cloud-toolbar-wrap {
     top: 3.35rem;
+  }
+
+  .cloud-headline {
+    flex-wrap: wrap;
+  }
+
+  .cloud-entry-name {
+    max-width: 14rem;
+  }
+}
+
+@media (max-width: 640px) {
+  :host ::ng-deep .cloud-table .p-datatable-thead > tr > th:nth-child(2),
+  :host ::ng-deep .cloud-table .p-datatable-thead > tr > th:nth-child(3),
+  :host ::ng-deep .cloud-table .p-datatable-tbody > tr > td:nth-child(2),
+  :host ::ng-deep .cloud-table .p-datatable-tbody > tr > td:nth-child(3) {
+    display: none;
+  }
+}
+
+@media (max-width: 420px) {
+  :host ::ng-deep .cloud-table .p-datatable-thead > tr > th:nth-child(4),
+  :host ::ng-deep .cloud-table .p-datatable-tbody > tr > td:nth-child(4) {
+    display: none;
+  }
+
+  .cloud-entry-name {
+    max-width: 9rem;
   }
 }

--- a/frontend/src/app/pages/cloud/cloud.component.scss
+++ b/frontend/src/app/pages/cloud/cloud.component.scss
@@ -41,6 +41,17 @@
   padding: 0.38rem 0.48rem;
 }
 
+:host ::ng-deep .cloud-toolbar .p-toolbar-group-start,
+:host ::ng-deep .cloud-toolbar .p-toolbar-group-end {
+  min-width: 0;
+}
+
+:host ::ng-deep .cloud-toolbar .p-toolbar-group-end {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
 .cloud-toolbar-start {
   display: flex;
   align-items: center;
@@ -89,12 +100,32 @@
   border: 0;
   padding: 0;
   background: transparent;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+}
+
+:host ::ng-deep .cloud-breadcrumb .p-breadcrumb-list {
+  flex-wrap: nowrap;
+  min-width: 0;
+}
+
+:host ::ng-deep .cloud-breadcrumb .p-menuitem-link {
+  min-width: 0;
+  max-width: 10rem;
 }
 
 :host ::ng-deep .cloud-breadcrumb .p-breadcrumb-list li .p-menuitem-link,
 :host ::ng-deep .cloud-breadcrumb .p-breadcrumb-list li .p-menuitem-text,
 :host ::ng-deep .cloud-breadcrumb .p-breadcrumb-list li .p-breadcrumb-home {
   color: var(--color-text-secondary);
+}
+
+:host ::ng-deep .cloud-breadcrumb .p-breadcrumb-list li .p-menuitem-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 :host
@@ -139,6 +170,7 @@
   border-color: color-mix(in srgb, #ef4444 45%, var(--color-border));
   background: color-mix(in srgb, #ef4444 10%, transparent);
 }
+
 .cloud-table-wrap {
   border-radius: 1rem;
   border: 1px solid var(--color-border);
@@ -359,6 +391,24 @@
     flex-wrap: wrap;
   }
 
+  .cloud-headline-actions {
+    flex-wrap: wrap;
+  }
+
+  :host ::ng-deep .cloud-toolbar {
+    align-items: stretch;
+    gap: 0.45rem;
+  }
+
+  :host ::ng-deep .cloud-toolbar .p-toolbar-group-start,
+  :host ::ng-deep .cloud-toolbar .p-toolbar-group-end {
+    width: 100%;
+  }
+
+  :host ::ng-deep .cloud-breadcrumb .p-menuitem-link {
+    max-width: 7rem;
+  }
+
   .cloud-entry-name {
     max-width: 14rem;
   }
@@ -381,5 +431,9 @@
 
   .cloud-entry-name {
     max-width: 9rem;
+  }
+
+  :host ::ng-deep .cloud-breadcrumb .p-menuitem-link {
+    max-width: 5.5rem;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #252 — CloudPage table breaks on mobile due to missing responsive styles.

**Root cause:** `.cloud-table-wrap` had `overflow: hidden` which clips the 5-column table horizontally on narrow viewports instead of allowing a scroll or hiding non-essential columns.

**Changes:**
- `overflow: hidden` → `overflow-x: auto / overflow-y: hidden` on `.cloud-table-wrap` so the table can scroll horizontally as a fallback
- Hide **Size** and **Type** columns below 640 px — least essential metadata on small screens
- Hide **Modified** column below 420 px for very small devices
- Wrap `.cloud-headline` at 768 px so title + action buttons don't overflow
- Shrink `.cloud-entry-name` max-width at 768 px / 420 px to fit the narrower Name cell

## Test plan

- [ ] Open CloudPage on a 375 px wide viewport — table should show Name + Actions only, no horizontal overflow
- [ ] Resize to 480 px — Size and Type columns reappear
- [ ] Resize to desktop — all 5 columns visible, layout unchanged
- [ ] Verify dark-theme styles still apply correctly
