### PR TITLE
Add drag-and-drop support for external file uploads

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -419,6 +419,7 @@
       "integrity": "sha512-CVskZnF38IIxVVlKWi1VCz7YH/gHMJu2IY9bD1AVoBBGIe0xA4FRXJkW2Y+EDs9vQqZTkZZljhK5gL65Ro1PeQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "20.7.0",
         "eslint-scope": "^9.0.0"
@@ -448,6 +449,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.2.17.tgz",
       "integrity": "sha512-6VTet2fzTpSHEjxcVVzL8ZIyNGo/qsUs4XF/3wh9Iwu6qfWx711qXKlqGD/IHWzMTumzvQXbTV4hzvnO7fJvIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -600,6 +602,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.17.tgz",
       "integrity": "sha512-yFUXAdpvOFirGD/EGDwp1WHravHzI4sdyRE2iH7i8im9l8IE2VZ6D1KDJp8VVpMJt38LNlRAWYek3s+z6OcAkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -616,6 +619,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.17.tgz",
       "integrity": "sha512-qo8psYASAlDiQ8fAL8i/E2JfWH2nPTpZDKKZxSWvgBVA8o+zUEjYAJu6/k6btnu+4Qcb425T0rmM/zao6EU9Aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -629,6 +633,7 @@
       "integrity": "sha512-KG82fh2A0odttc6+FxlQmFfHY/Giq8rYeV1qtdafafJ8hdWIiMr4r37xwhZOl8uk2/XSLM66bxUMFHYm+zt87Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.26.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -705,6 +710,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.17.tgz",
       "integrity": "sha512-nVu0ryxfiXUZ9M+NV21TY+rJZkPXTYo9U0aJb19hvByPpG+EvuujXUOgpulz6vxIzGy7pz/znRa+K9kxuuC+yQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -721,6 +727,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.2.17.tgz",
       "integrity": "sha512-INgGGmMbwXuT+niAjMiCsJrZVEGWKZOep1vCRHoKlVnGUQSRKc3UW8ztmKDKMua/io/Opi03pRMpwbYQcTBr5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -739,6 +746,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.17.tgz",
       "integrity": "sha512-Rn23nIQwYMSeGXWFHI/X8bGHAkdahRxH9UIGUlJKxW61MSkK6AW4kCHG/Ev1TvDq9HjijsMjcqcsd6/Sb8aBXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -779,6 +787,7 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.2.17.tgz",
       "integrity": "sha512-B3Vk+E8UHQwg06WEjGuvYaKNiIXxjHN9pN8S+hDE8xwRgIS5ojEwS94blEvsGQ4QsIja6WjZMOfDUBUPlgUSuA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -823,6 +832,7 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -3372,6 +3382,7 @@
       "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.1.2",
         "@inquirer/confirm": "^5.1.6",
@@ -5946,6 +5957,7 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6106,6 +6118,7 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -6213,6 +6226,7 @@
       "integrity": "sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6281,6 +6295,7 @@
       "integrity": "sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.50.0",
@@ -6565,6 +6580,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6627,6 +6643,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7133,6 +7150,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8605,6 +8623,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10400,7 +10419,8 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
       "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -10552,6 +10572,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -10923,6 +10944,7 @@
       "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -13139,6 +13161,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13863,6 +13886,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -15105,6 +15129,7 @@
       "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -15284,7 +15309,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "3.1.0",
@@ -15341,6 +15367,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16025,6 +16052,7 @@
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -16102,6 +16130,7 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -16703,7 +16732,8 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -419,7 +419,6 @@
       "integrity": "sha512-CVskZnF38IIxVVlKWi1VCz7YH/gHMJu2IY9bD1AVoBBGIe0xA4FRXJkW2Y+EDs9vQqZTkZZljhK5gL65Ro1PeQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "20.7.0",
         "eslint-scope": "^9.0.0"
@@ -449,7 +448,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.2.17.tgz",
       "integrity": "sha512-6VTet2fzTpSHEjxcVVzL8ZIyNGo/qsUs4XF/3wh9Iwu6qfWx711qXKlqGD/IHWzMTumzvQXbTV4hzvnO7fJvIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -602,7 +600,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.17.tgz",
       "integrity": "sha512-yFUXAdpvOFirGD/EGDwp1WHravHzI4sdyRE2iH7i8im9l8IE2VZ6D1KDJp8VVpMJt38LNlRAWYek3s+z6OcAkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -619,7 +616,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.17.tgz",
       "integrity": "sha512-qo8psYASAlDiQ8fAL8i/E2JfWH2nPTpZDKKZxSWvgBVA8o+zUEjYAJu6/k6btnu+4Qcb425T0rmM/zao6EU9Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -633,7 +629,6 @@
       "integrity": "sha512-KG82fh2A0odttc6+FxlQmFfHY/Giq8rYeV1qtdafafJ8hdWIiMr4r37xwhZOl8uk2/XSLM66bxUMFHYm+zt87Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.26.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -710,7 +705,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.17.tgz",
       "integrity": "sha512-nVu0ryxfiXUZ9M+NV21TY+rJZkPXTYo9U0aJb19hvByPpG+EvuujXUOgpulz6vxIzGy7pz/znRa+K9kxuuC+yQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -727,7 +721,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.2.17.tgz",
       "integrity": "sha512-INgGGmMbwXuT+niAjMiCsJrZVEGWKZOep1vCRHoKlVnGUQSRKc3UW8ztmKDKMua/io/Opi03pRMpwbYQcTBr5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -746,7 +739,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.17.tgz",
       "integrity": "sha512-Rn23nIQwYMSeGXWFHI/X8bGHAkdahRxH9UIGUlJKxW61MSkK6AW4kCHG/Ev1TvDq9HjijsMjcqcsd6/Sb8aBXg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -787,7 +779,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.2.17.tgz",
       "integrity": "sha512-B3Vk+E8UHQwg06WEjGuvYaKNiIXxjHN9pN8S+hDE8xwRgIS5ojEwS94blEvsGQ4QsIja6WjZMOfDUBUPlgUSuA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -832,7 +823,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -3382,7 +3372,6 @@
       "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.1.2",
         "@inquirer/confirm": "^5.1.6",
@@ -5957,7 +5946,6 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6118,7 +6106,6 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -6226,7 +6213,6 @@
       "integrity": "sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6295,7 +6281,6 @@
       "integrity": "sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.50.0",
@@ -6580,7 +6565,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6643,7 +6627,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7150,7 +7133,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8623,7 +8605,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10419,8 +10400,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
       "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -10572,7 +10552,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -10944,7 +10923,6 @@
       "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -13161,7 +13139,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13886,7 +13863,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -15129,7 +15105,6 @@
       "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -15309,8 +15284,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "3.1.0",
@@ -15367,7 +15341,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16052,7 +16025,6 @@
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -16130,7 +16102,6 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -16732,8 +16703,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -129,7 +129,14 @@
     {{ error }}
   </div>
 
-  <section *ngIf="currentFolder && !loading" class="cloud-table-wrap">
+  <section
+  *ngIf="currentFolder && !loading"
+  class="cloud-table-wrap"
+  [class.drag-over]="isExternalDrag"
+  (dragover)="onExternalDragOver($event)"
+  (dragleave)="onExternalDragLeave($event)"
+  (drop)="onExternalDrop($event)"
+>
     <p-table
       [value]="entries"
       [lazy]="!searchActive"

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -130,13 +130,13 @@
   </div>
 
   <section
-  *ngIf="currentFolder && !loading"
-  class="cloud-table-wrap"
-  [class.drag-over]="isExternalDrag"
-  (dragover)="onExternalDragOver($event)"
-  (dragleave)="onExternalDragLeave($event)"
-  (drop)="onExternalDrop($event)"
->
+    *ngIf="currentFolder && !loading"
+    class="cloud-table-wrap"
+    [class.drag-over]="isExternalDrag"
+    (dragover)="onExternalDragOver($event)"
+    (dragleave)="onExternalDragLeave($event)"
+    (drop)="onExternalDrop($event)"
+  >
     <p-table
       [value]="entries"
       [lazy]="!searchActive"

--- a/frontend/src/app/pages/cloud/cloud.component.scss
+++ b/frontend/src/app/pages/cloud/cloud.component.scss
@@ -153,15 +153,10 @@
 // Highlight the table while external files are dragged over it.
 .cloud-table-wrap.drag-over {
   border-color: var(--color-primary);
-  background: color-mix(
-    in srgb,
-    var(--color-primary) 8%,
-    var(--color-surface)
-  );
+  background: color-mix(in srgb, var(--color-primary) 8%, var(--color-surface));
   box-shadow: 0 0 0 2px
     color-mix(in srgb, var(--color-primary) 25%, transparent);
 }
-
 
 :host ::ng-deep .cloud-table .p-datatable-table {
   font-size: inherit;

--- a/frontend/src/app/pages/cloud/cloud.component.scss
+++ b/frontend/src/app/pages/cloud/cloud.component.scss
@@ -139,14 +139,29 @@
   border-color: color-mix(in srgb, #ef4444 45%, var(--color-border));
   background: color-mix(in srgb, #ef4444 10%, transparent);
 }
-
 .cloud-table-wrap {
   border-radius: 1rem;
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   box-shadow: 0 6px 14px -14px var(--color-shadow-md);
   overflow: hidden;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease;
 }
+// Highlight the table while external files are dragged over it.
+.cloud-table-wrap.drag-over {
+  border-color: var(--color-primary);
+  background: color-mix(
+    in srgb,
+    var(--color-primary) 8%,
+    var(--color-surface)
+  );
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--color-primary) 25%, transparent);
+}
+
 
 :host ::ng-deep .cloud-table .p-datatable-table {
   font-size: inherit;

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -102,8 +102,9 @@ export class CloudComponent implements OnInit {
   private contentRequestId = 0;
 
   private draggedPath: string | null = null;
-  private draggedIsFolder = false;
-  draggedOverPath: string | null = null;
+private draggedIsFolder = false;
+draggedOverPath: string | null = null;
+isExternalDrag = false;
 
   constructor(
     private cloudService: CloudService,
@@ -582,6 +583,45 @@ export class CloudComponent implements OnInit {
 
     input.value = '';
   }
+  onExternalDragOver(event: DragEvent) {
+  if (this.draggedPath) return;
+
+  event.preventDefault();
+  this.isExternalDrag = true;
+
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = 'copy';
+  }
+}
+onExternalDragLeave(event: DragEvent) {
+  const currentTarget = event.currentTarget as HTMLElement;
+  const relatedTarget = event.relatedTarget as Node | null;
+
+  if (!relatedTarget || !currentTarget.contains(relatedTarget)) {
+    this.isExternalDrag = false;
+  }
+}
+
+onExternalDrop(event: DragEvent) {
+  event.preventDefault();
+  this.isExternalDrag = false;
+
+  if (this.draggedPath) {
+    return;
+  }
+
+  const files = event.dataTransfer?.files;
+
+  if (!files || files.length === 0) {
+    return;
+  }
+
+  const currentPath = this.getRelativePath(this.currentFolder?.path || '/');
+
+  for (const file of Array.from(files)) {
+    this.uploadFile(currentPath, file);
+  }
+}
 
   confirmDeleteFolder(folderPath: string) {
     this.confirmationService.confirm({

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -102,9 +102,9 @@ export class CloudComponent implements OnInit {
   private contentRequestId = 0;
 
   private draggedPath: string | null = null;
-private draggedIsFolder = false;
-draggedOverPath: string | null = null;
-isExternalDrag = false;
+  private draggedIsFolder = false;
+  draggedOverPath: string | null = null;
+  isExternalDrag = false;
 
   constructor(
     private cloudService: CloudService,
@@ -584,44 +584,44 @@ isExternalDrag = false;
     input.value = '';
   }
   onExternalDragOver(event: DragEvent) {
-  if (this.draggedPath) return;
+    if (this.draggedPath) return;
 
-  event.preventDefault();
-  this.isExternalDrag = true;
+    event.preventDefault();
+    this.isExternalDrag = true;
 
-  if (event.dataTransfer) {
-    event.dataTransfer.dropEffect = 'copy';
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
   }
-}
-onExternalDragLeave(event: DragEvent) {
-  const currentTarget = event.currentTarget as HTMLElement;
-  const relatedTarget = event.relatedTarget as Node | null;
+  onExternalDragLeave(event: DragEvent) {
+    const currentTarget = event.currentTarget as HTMLElement;
+    const relatedTarget = event.relatedTarget as Node | null;
 
-  if (!relatedTarget || !currentTarget.contains(relatedTarget)) {
+    if (!relatedTarget || !currentTarget.contains(relatedTarget)) {
+      this.isExternalDrag = false;
+    }
+  }
+
+  onExternalDrop(event: DragEvent) {
+    event.preventDefault();
     this.isExternalDrag = false;
+
+    if (this.draggedPath) {
+      return;
+    }
+
+    const files = event.dataTransfer?.files;
+
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    const currentPath = this.getRelativePath(this.currentFolder?.path || '/');
+
+    for (const file of Array.from(files)) {
+      this.uploadFile(currentPath, file);
+    }
   }
-}
-
-onExternalDrop(event: DragEvent) {
-  event.preventDefault();
-  this.isExternalDrag = false;
-
-  if (this.draggedPath) {
-    return;
-  }
-
-  const files = event.dataTransfer?.files;
-
-  if (!files || files.length === 0) {
-    return;
-  }
-
-  const currentPath = this.getRelativePath(this.currentFolder?.path || '/');
-
-  for (const file of Array.from(files)) {
-    this.uploadFile(currentPath, file);
-  }
-}
 
   confirmDeleteFolder(folderPath: string) {
     this.confirmationService.confirm({

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -586,12 +586,17 @@ export class CloudComponent implements OnInit {
   onExternalDragOver(event: DragEvent) {
     if (this.draggedPath) return;
 
+    const isFileDrag =
+      !!event.dataTransfer &&
+      Array.from(event.dataTransfer.types).includes('Files');
+
+    if (!isFileDrag) {
+      return;
+    }
+
     event.preventDefault();
     this.isExternalDrag = true;
-
-    if (event.dataTransfer) {
-      event.dataTransfer.dropEffect = 'copy';
-    }
+    event.dataTransfer!.dropEffect = 'copy';
   }
   onExternalDragLeave(event: DragEvent) {
     const currentTarget = event.currentTarget as HTMLElement;


### PR DESCRIPTION
## Summary

This PR adds support for uploading files by dragging them from the desktop into the Cloud view.

### Changes
- Added dragover and drop event handlers to the cloud table container.
- Prevented the browser's default drag behavior for external file drops.
- Reused the existing upload logic for dropped files.
- Added visual feedback while external files are dragged over the drop zone.

### Notes
- Existing drag-and-drop functionality for moving files and folders within the cloud view is preserved.

### Testing

## Testing

- Verified that the frontend builds successfully.
- Reviewed that the implementation reuses the existing upload flow.
- Full end-to-end testing could not be completed because the Cloud service expected on port 8090 is not available in the local development setup.