### PR TITLE
Add E2EE emoji and sticker support for private and group chats

### DIFF
--- a/backend/src/main/java/vaultWeb/controllers/ChatController.java
+++ b/backend/src/main/java/vaultWeb/controllers/ChatController.java
@@ -1,6 +1,7 @@
 package vaultWeb.controllers;
 
 import jakarta.validation.Valid;
+import java.security.Principal;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -8,9 +9,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Controller;
 import vaultWeb.dtos.ChatMessageDto;
+import vaultWeb.exceptions.UnauthorizedException;
 import vaultWeb.models.ChatMessage;
+import vaultWeb.repositories.GroupMemberRepository;
 import vaultWeb.services.ChatService;
 
 /**
@@ -26,6 +30,7 @@ public class ChatController {
 
   private final SimpMessagingTemplate messagingTemplate;
   private final ChatService chatService;
+  private final GroupMemberRepository groupMemberRepository;
 
   /**
    * Handles incoming group chat messages from clients and broadcasts them to all subscribers of the
@@ -34,7 +39,8 @@ public class ChatController {
    * @param messageDto DTO containing message content, sender information, and target group
    */
   @MessageMapping("/chat.send")
-  public void sendMessage(@Valid @Payload ChatMessageDto messageDto) {
+  public void sendMessage(@Valid @Payload ChatMessageDto messageDto, Principal principal) {
+    authorizeGroupMessage(messageDto, principal);
     ChatMessage savedMessage = chatService.saveMessage(messageDto);
 
     ChatMessageDto responseDto = new ChatMessageDto();
@@ -46,6 +52,25 @@ public class ChatController {
 
     messagingTemplate.convertAndSend(
         "/topic/group/" + savedMessage.getGroup().getId(), responseDto);
+  }
+
+  private void authorizeGroupMessage(ChatMessageDto messageDto, Principal principal) {
+    if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+      throw new UnauthorizedException("User not authenticated");
+    }
+    if (messageDto.getGroupId() == null) {
+      throw new IllegalArgumentException("Group ID is required for group messages");
+    }
+
+    String username = principal.getName();
+    boolean isMember =
+        groupMemberRepository.existsByGroupIdAndUserUsername(messageDto.getGroupId(), username);
+    if (!isMember) {
+      throw new AccessDeniedException("Not allowed to send messages to this group");
+    }
+
+    messageDto.setSenderId(null);
+    messageDto.setSenderUsername(username);
   }
 
   /**

--- a/backend/src/main/java/vaultWeb/controllers/GroupController.java
+++ b/backend/src/main/java/vaultWeb/controllers/GroupController.java
@@ -6,13 +6,17 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import vaultWeb.dtos.ChatMessageDto;
 import vaultWeb.dtos.DeviceDto;
 import vaultWeb.dtos.GroupDto;
 import vaultWeb.exceptions.UnauthorizedException;
 import vaultWeb.exceptions.notfound.NotMemberException;
+import vaultWeb.models.ChatMessage;
 import vaultWeb.models.Group;
 import vaultWeb.models.User;
+import vaultWeb.repositories.ChatMessageRepository;
 import vaultWeb.repositories.DeviceRepository;
 import vaultWeb.repositories.GroupMemberRepository;
 import vaultWeb.security.annotations.AdminOnly;
@@ -35,6 +39,7 @@ public class GroupController {
   private final AuthService authService;
   private final GroupMemberRepository groupMemberRepository;
   private final DeviceRepository deviceRepository;
+  private final ChatMessageRepository chatMessageRepository;
 
   /**
    * Retrieves all public groups.
@@ -102,6 +107,54 @@ public class GroupController {
     List<DeviceDto> devices =
         deviceRepository.findByUserIn(members).stream().map(DeviceDto::from).toList();
     return ResponseEntity.ok(devices);
+  }
+
+  @GetMapping("/{id}/messages")
+  @Operation(
+      summary = "Get all messages of a group chat",
+      description =
+          """
+                    Retrieves all messages from a group chat.
+                    - The current user must be a group member.
+                    - Messages are ordered chronologically by timestamp.
+                    - Message content remains end-to-end encrypted and is never decrypted by the server.
+                    """)
+  public ResponseEntity<List<ChatMessageDto>> getGroupMessages(
+      @PathVariable Long id, Authentication authentication) {
+    User currentUser = getAuthenticatedGroupMember(id, authentication);
+    List<ChatMessage> messages = chatMessageRepository.findByGroupIdOrderByTimestampAsc(id);
+
+    List<ChatMessageDto> response =
+        messages.stream()
+            .map(
+                message -> {
+                  ChatMessageDto dto = new ChatMessageDto();
+                  dto.setE2eePayload(message.getE2eePayload());
+                  dto.setTimestamp(message.getTimestamp().toString());
+                  dto.setGroupId(id);
+                  dto.setPrivateChatId(null);
+                  dto.setSenderId(message.getSender().getId());
+                  dto.setSenderUsername(message.getSender().getUsername());
+                  dto.setSenderDeviceId(message.getSenderDeviceId());
+                  return dto;
+                })
+            .toList();
+
+    return ResponseEntity.ok(response);
+  }
+
+  private User getAuthenticatedGroupMember(Long groupId, Authentication authentication) {
+    if (authentication == null) {
+      throw new UnauthorizedException("User not authenticated");
+    }
+    User currentUser = authService.getCurrentUser();
+    if (currentUser == null) {
+      throw new UnauthorizedException("User not authenticated");
+    }
+    if (groupMemberRepository.findByGroupIdAndUserId(groupId, currentUser.getId()).isEmpty()) {
+      throw new NotMemberException(groupId, currentUser.getId());
+    }
+    return currentUser;
   }
 
   /**

--- a/backend/src/main/java/vaultWeb/repositories/ChatMessageRepository.java
+++ b/backend/src/main/java/vaultWeb/repositories/ChatMessageRepository.java
@@ -11,6 +11,8 @@ import vaultWeb.models.User;
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
   List<ChatMessage> findByPrivateChatIdOrderByTimestampAsc(Long privateChatId);
 
+  List<ChatMessage> findByGroupIdOrderByTimestampAsc(Long groupId);
+
   long countBySender(User sender);
 
   List<ChatMessage> findTop10BySenderOrderByTimestampDesc(User sender);

--- a/backend/src/main/java/vaultWeb/repositories/GroupMemberRepository.java
+++ b/backend/src/main/java/vaultWeb/repositories/GroupMemberRepository.java
@@ -15,6 +15,8 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 
   Optional<GroupMember> findByGroupIdAndUserId(Long groupId, Long userId);
 
+  boolean existsByGroupIdAndUserUsername(Long groupId, String username);
+
   List<GroupMember> findAllByGroup(Group group);
 
   List<GroupMember> findAllByUser(User user);

--- a/backend/src/test/java/vaultWeb/controllers/ChatControllerTest.java
+++ b/backend/src/test/java/vaultWeb/controllers/ChatControllerTest.java
@@ -1,0 +1,103 @@
+package vaultWeb.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.Principal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.AccessDeniedException;
+import vaultWeb.dtos.ChatMessageDto;
+import vaultWeb.exceptions.UnauthorizedException;
+import vaultWeb.models.ChatMessage;
+import vaultWeb.models.Group;
+import vaultWeb.models.User;
+import vaultWeb.repositories.GroupMemberRepository;
+import vaultWeb.services.ChatService;
+
+@ExtendWith(MockitoExtension.class)
+class ChatControllerTest {
+
+  private static final String SENDER_DEVICE_ID = "device-1";
+  private static final String E2EE_PAYLOAD = "{\"v\":2}";
+
+  @Mock private SimpMessagingTemplate messagingTemplate;
+
+  @Mock private ChatService chatService;
+
+  @Mock private GroupMemberRepository groupMemberRepository;
+
+  @InjectMocks private ChatController chatController;
+
+  @Test
+  void shouldSendGroupMessage_WhenAuthenticatedUserIsGroupMember() {
+    ChatMessageDto request = createGroupMessageRequest(10L);
+    Principal principal = () -> "alice";
+    ChatMessage savedMessage = createSavedGroupMessage(10L, "alice");
+
+    when(groupMemberRepository.existsByGroupIdAndUserUsername(10L, "alice")).thenReturn(true);
+    when(chatService.saveMessage(any(ChatMessageDto.class))).thenReturn(savedMessage);
+
+    chatController.sendMessage(request, principal);
+
+    ArgumentCaptor<ChatMessageDto> dtoCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+    verify(chatService).saveMessage(dtoCaptor.capture());
+    assertEquals("alice", dtoCaptor.getValue().getSenderUsername());
+    verify(messagingTemplate).convertAndSend(eq("/topic/group/10"), any(ChatMessageDto.class));
+  }
+
+  @Test
+  void shouldRejectGroupMessage_WhenAuthenticatedUserIsNotGroupMember() {
+    ChatMessageDto request = createGroupMessageRequest(10L);
+    Principal principal = () -> "mallory";
+
+    when(groupMemberRepository.existsByGroupIdAndUserUsername(10L, "mallory")).thenReturn(false);
+
+    assertThrows(AccessDeniedException.class, () -> chatController.sendMessage(request, principal));
+    verify(chatService, never()).saveMessage(any());
+    verify(messagingTemplate, never()).convertAndSend(any(String.class), any(ChatMessageDto.class));
+  }
+
+  @Test
+  void shouldRejectGroupMessage_WhenUnauthenticated() {
+    ChatMessageDto request = createGroupMessageRequest(10L);
+
+    assertThrows(UnauthorizedException.class, () -> chatController.sendMessage(request, null));
+    verify(groupMemberRepository, never()).existsByGroupIdAndUserUsername(any(), any());
+    verify(chatService, never()).saveMessage(any());
+    verify(messagingTemplate, never()).convertAndSend(any(String.class), any(ChatMessageDto.class));
+  }
+
+  private ChatMessageDto createGroupMessageRequest(Long groupId) {
+    ChatMessageDto dto = new ChatMessageDto();
+    dto.setGroupId(groupId);
+    dto.setSenderUsername("spoofed-sender");
+    dto.setSenderDeviceId(SENDER_DEVICE_ID);
+    dto.setE2eePayload(E2EE_PAYLOAD);
+    return dto;
+  }
+
+  private ChatMessage createSavedGroupMessage(Long groupId, String username) {
+    User sender = new User();
+    sender.setUsername(username);
+    Group group = new Group();
+    group.setId(groupId);
+    ChatMessage message = new ChatMessage();
+    message.setGroup(group);
+    message.setSender(sender);
+    message.setSenderDeviceId(SENDER_DEVICE_ID);
+    message.setE2eePayload(E2EE_PAYLOAD);
+    message.setTimestamp(java.time.Instant.parse("2026-03-26T10:15:30Z"));
+    return message;
+  }
+}

--- a/backend/src/test/java/vaultWeb/controllers/GroupControllerTest.java
+++ b/backend/src/test/java/vaultWeb/controllers/GroupControllerTest.java
@@ -19,15 +19,19 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import vaultWeb.dtos.ChatMessageDto;
 import vaultWeb.dtos.DeviceDto;
 import vaultWeb.dtos.GroupDto;
 import vaultWeb.exceptions.AlreadyMemberException;
 import vaultWeb.exceptions.UnauthorizedException;
 import vaultWeb.exceptions.notfound.GroupNotFoundException;
 import vaultWeb.exceptions.notfound.NotMemberException;
+import vaultWeb.models.ChatMessage;
 import vaultWeb.models.Device;
 import vaultWeb.models.Group;
 import vaultWeb.models.User;
+import vaultWeb.repositories.ChatMessageRepository;
 import vaultWeb.repositories.DeviceRepository;
 import vaultWeb.repositories.GroupMemberRepository;
 import vaultWeb.services.GroupService;
@@ -41,6 +45,7 @@ class GroupControllerTest {
   @Mock private AuthService authService;
   @Mock private GroupMemberRepository groupMemberRepository;
   @Mock private DeviceRepository deviceRepository;
+  @Mock private ChatMessageRepository chatMessageRepository;
 
   @InjectMocks private GroupController groupController;
 
@@ -325,5 +330,50 @@ class GroupControllerTest {
     assertThrows(UnauthorizedException.class, () -> groupController.getGroupDevices(10L));
     verify(groupMemberRepository, times(0)).findByGroupIdAndUserId(any(), any());
     verify(deviceRepository, times(0)).findByUserIn(any());
+  }
+
+  @Test
+  void shouldGetGroupMessages_WhenUserIsMember() {
+    User currentUser = createTestUser(1L, "member");
+    User sender = createTestUser(2L, "sender");
+    ChatMessage message = new ChatMessage();
+    message.setSender(sender);
+    message.setSenderDeviceId("sender-device");
+    message.setE2eePayload("{\"v\":2}");
+    message.setTimestamp(java.time.Instant.parse("2026-03-26T10:15:30Z"));
+    Authentication authentication = mock(Authentication.class);
+
+    when(authService.getCurrentUser()).thenReturn(currentUser);
+    when(groupMemberRepository.findByGroupIdAndUserId(10L, 1L))
+        .thenReturn(Optional.of(mock(vaultWeb.models.GroupMember.class)));
+    when(chatMessageRepository.findByGroupIdOrderByTimestampAsc(10L)).thenReturn(List.of(message));
+
+    ResponseEntity<List<ChatMessageDto>> response =
+        groupController.getGroupMessages(10L, authentication);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(1, response.getBody().size());
+    assertEquals("{\"v\":2}", response.getBody().get(0).getE2eePayload());
+    assertEquals(10L, response.getBody().get(0).getGroupId());
+    assertEquals("sender", response.getBody().get(0).getSenderUsername());
+  }
+
+  @Test
+  void shouldRejectGetGroupMessages_WhenUserIsNotMember() {
+    User currentUser = createTestUser(1L, "member");
+    Authentication authentication = mock(Authentication.class);
+
+    when(authService.getCurrentUser()).thenReturn(currentUser);
+    when(groupMemberRepository.findByGroupIdAndUserId(10L, 1L)).thenReturn(Optional.empty());
+
+    assertThrows(
+        NotMemberException.class, () -> groupController.getGroupMessages(10L, authentication));
+    verify(chatMessageRepository, times(0)).findByGroupIdOrderByTimestampAsc(any());
+  }
+
+  @Test
+  void shouldRejectGetGroupMessages_WhenUnauthenticated() {
+    assertThrows(UnauthorizedException.class, () -> groupController.getGroupMessages(10L, null));
+    verify(chatMessageRepository, times(0)).findByGroupIdOrderByTimestampAsc(any());
   }
 }

--- a/frontend/public/stickers/heart.svg
+++ b/frontend/public/stickers/heart.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Heart sticker</title>
+  <desc id="desc">A cheerful heart with small shine marks.</desc>
+  <rect width="160" height="160" rx="32" fill="#fdf2f8"/>
+  <path d="M80 129s-48-28-58-62c-6-21 6-39 26-39 13 0 24 8 32 20 8-12 19-20 32-20 20 0 32 18 26 39-10 34-58 62-58 62z" fill="#fb7185"/>
+  <path d="M56 46c-10 0-18 8-18 19" fill="none" stroke="#ffe4e6" stroke-width="10" stroke-linecap="round"/>
+  <circle cx="67" cy="78" r="4" fill="#881337"/>
+  <circle cx="94" cy="78" r="4" fill="#881337"/>
+  <path d="M70 93c6 5 15 5 21 0" fill="none" stroke="#881337" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/stickers/party.svg
+++ b/frontend/public/stickers/party.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Party sticker</title>
+  <desc id="desc">A colorful party popper with confetti.</desc>
+  <rect width="160" height="160" rx="32" fill="#f0fdf4"/>
+  <path d="M44 118l28-71 42 42z" fill="#22c55e"/>
+  <path d="M55 91l17-44 42 42-44 17z" fill="#a78bfa"/>
+  <path d="M44 118l26-12-14-14z" fill="#16a34a"/>
+  <circle cx="114" cy="37" r="8" fill="#fb7185"/>
+  <circle cx="78" cy="27" r="6" fill="#38bdf8"/>
+  <circle cx="126" cy="70" r="6" fill="#facc15"/>
+  <path d="M104 56l20-18M91 42l4-22M119 85l22-2" stroke="#0f766e" stroke-width="6" stroke-linecap="round"/>
+  <path d="M70 106l-13-13M84 100l-20-20M98 92l-27-27" stroke="#ede9fe" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/stickers/spark.svg
+++ b/frontend/public/stickers/spark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Spark sticker</title>
+  <desc id="desc">A bright star burst with a smiling center.</desc>
+  <rect width="160" height="160" rx="32" fill="#fff7ed"/>
+  <path d="M80 18l13 38 40-13-21 35 32 25-40 6 3 41-27-31-27 31 3-41-40-6 32-25-21-35 40 13z" fill="#facc15"/>
+  <path d="M80 31l10 31 32-10-17 28 26 20-33 5 3 33-21-25-21 25 3-33-33-5 26-20-17-28 32 10z" fill="#fb923c"/>
+  <circle cx="80" cy="83" r="25" fill="#fff7ed"/>
+  <circle cx="70" cy="78" r="4" fill="#7c2d12"/>
+  <circle cx="90" cy="78" r="4" fill="#7c2d12"/>
+  <path d="M68 91c7 8 17 8 24 0" fill="none" stroke="#7c2d12" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/stickers/thumbs-up.svg
+++ b/frontend/public/stickers/thumbs-up.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Thumbs up sticker</title>
+  <desc id="desc">A bold thumbs up sign inside a blue tile.</desc>
+  <rect width="160" height="160" rx="32" fill="#eff6ff"/>
+  <path d="M61 72h-23c-6 0-11 5-11 11v38c0 6 5 11 11 11h23z" fill="#60a5fa"/>
+  <path d="M61 72c12-12 19-27 21-45 1-7 8-11 15-8 8 3 12 12 10 20l-5 24h23c11 0 19 10 17 21l-7 34c-2 9-10 15-19 15H61z" fill="#fbbf24"/>
+  <path d="M61 72v61" stroke="#d97706" stroke-width="7" stroke-linecap="round"/>
+  <path d="M101 63h23c8 0 14 7 13 15" fill="none" stroke="#f59e0b" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="45" cy="104" r="5" fill="#1d4ed8"/>
+</svg>

--- a/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -59,8 +59,12 @@
 
           <div class="group-grid" *ngIf="data.groups.length">
             <article
-              class="group-card"
+              class="group-card cursor-pointer"
               *ngFor="let group of data.groups; trackBy: trackById"
+              role="button"
+              tabindex="0"
+              (click)="openGroupChat(group)"
+              (keydown)="onGroupChatKeydown($event, group)"
             >
               <div class="group-heading">
                 <h3>{{ group.name }}</h3>
@@ -183,7 +187,9 @@
                   let message of recentMessagesLimited;
                   trackBy: trackById
                 "
-                [class.timeline-entry-clickable]="!!message.privateChatId"
+                [class.timeline-entry-clickable]="
+                  !!message.privateChatId || !!message.groupId
+                "
                 role="button"
                 tabindex="0"
                 (click)="openRecentMessage(message)"
@@ -350,3 +356,12 @@
     </div>
   </ng-container>
 </div>
+
+<app-private-chat-dialog
+  *ngIf="selectedGroup"
+  chatMode="group"
+  [username]="selectedGroup.name"
+  [currentUsername]="currentUsername"
+  [groupId]="selectedGroup.id"
+  (closeChat)="closeGroupChat()"
+/>

--- a/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -187,11 +187,9 @@
                   let message of recentMessagesLimited;
                   trackBy: trackById
                 "
-                [class.timeline-entry-clickable]="
-                  !!message.privateChatId || !!message.groupId
-                "
-                role="button"
-                tabindex="0"
+                [class.timeline-entry-clickable]="canOpenRecentMessage(message)"
+                [attr.role]="canOpenRecentMessage(message) ? 'button' : null"
+                [attr.tabindex]="canOpenRecentMessage(message) ? 0 : -1"
                 (click)="openRecentMessage(message)"
                 (keydown)="onRecentMessageKeydown($event, message)"
               >

--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -18,6 +18,7 @@ import {
   PrivateChatSummary,
 } from '../../models/dtos/UserDashboardDto';
 import { PrivateChatDialogComponent } from '../private-chat-dialog/private-chat-dialog.component';
+import { UiToastService } from '../../core/services/ui-toast.service';
 
 interface StatHighlight {
   label: string;
@@ -54,6 +55,7 @@ export class DashboardComponent implements OnInit {
     private fb: FormBuilder,
     private authService: AuthService,
     private router: Router,
+    private toast: UiToastService,
   ) {
     this.passwordForm = this.createPasswordForm();
   }
@@ -105,6 +107,11 @@ export class DashboardComponent implements OnInit {
       const group = this.groupsById.get(message.groupId);
       if (group) {
         this.openGroupChat(group);
+      } else {
+        this.toast.warn(
+          'Group unavailable',
+          'This group chat is no longer available from your dashboard.',
+        );
       }
     }
   }
@@ -150,6 +157,13 @@ export class DashboardComponent implements OnInit {
     }
 
     return 'Activity';
+  }
+
+  canOpenRecentMessage(message: MessagePreview): boolean {
+    return (
+      !!message.privateChatId ||
+      (!!message.groupId && this.groupsById.has(message.groupId))
+    );
   }
 
   trackById(_: number, item: { id: number }): number {

--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -13,9 +13,11 @@ import { DashboardService } from '../../services/dashboard.service';
 import { UserDashboardDto } from '../../models/dtos/UserDashboardDto';
 import { AuthService } from '../../services/auth.service';
 import {
+  GroupSummary,
   MessagePreview,
   PrivateChatSummary,
 } from '../../models/dtos/UserDashboardDto';
+import { PrivateChatDialogComponent } from '../private-chat-dialog/private-chat-dialog.component';
 
 interface StatHighlight {
   label: string;
@@ -27,7 +29,7 @@ interface StatHighlight {
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, PrivateChatDialogComponent],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
 })
@@ -41,7 +43,9 @@ export class DashboardComponent implements OnInit {
   isSavingPassword = false;
   passwordSuccess = '';
   passwordError = '';
+  selectedGroup: GroupSummary | null = null;
   private privateChatParticipants = new Map<number, string>();
+  private groupsById = new Map<number, GroupSummary>();
   private readonly passwordComplexity =
     /(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).+/;
 
@@ -68,6 +72,22 @@ export class DashboardComponent implements OnInit {
     });
   }
 
+  openGroupChat(group: GroupSummary): void {
+    this.selectedGroup = group;
+  }
+
+  closeGroupChat(): void {
+    this.selectedGroup = null;
+  }
+
+  onGroupChatKeydown(event: KeyboardEvent, group: GroupSummary): void {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+    event.preventDefault();
+    this.openGroupChat(group);
+  }
+
   onPrivateChatKeydown(event: KeyboardEvent, chat: PrivateChatSummary): void {
     if (event.key !== 'Enter' && event.key !== ' ') {
       return;
@@ -77,12 +97,16 @@ export class DashboardComponent implements OnInit {
   }
 
   openRecentMessage(message: MessagePreview): void {
-    if (!message.privateChatId) {
-      return;
+    if (message.privateChatId) {
+      this.router.navigate(['/'], {
+        queryParams: { privateChatId: message.privateChatId },
+      });
+    } else if (message.groupId) {
+      const group = this.groupsById.get(message.groupId);
+      if (group) {
+        this.openGroupChat(group);
+      }
     }
-    this.router.navigate(['/'], {
-      queryParams: { privateChatId: message.privateChatId },
-    });
   }
 
   onRecentMessageKeydown(event: KeyboardEvent, message: MessagePreview): void {
@@ -136,6 +160,10 @@ export class DashboardComponent implements OnInit {
     return (
       this.dashboard?.recentMessages.slice(0, this.maxRecentMessages) ?? []
     );
+  }
+
+  get currentUsername(): string | null {
+    return this.authService.getUsername();
   }
 
   get hasMoreRecentMessages(): boolean {
@@ -206,6 +234,9 @@ export class DashboardComponent implements OnInit {
         this.dashboard = data;
         this.privateChatParticipants = new Map(
           data.privateChats.map((chat) => [chat.id, chat.participant]),
+        );
+        this.groupsById = new Map(
+          data.groups.map((group) => [group.id, group]),
         );
         this.isLoading = false;
         this.error = null;

--- a/frontend/src/app/pages/private-chat-dialog/chat-reactions.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-reactions.ts
@@ -1,0 +1,51 @@
+export interface ChatSticker {
+  id: string;
+  label: string;
+  src: string;
+}
+
+export const CHAT_EMOJIS = [
+  '😀',
+  '😂',
+  '😊',
+  '😍',
+  '😎',
+  '🥳',
+  '🤔',
+  '👍',
+  '🙏',
+  '🔥',
+  '✨',
+  '💙',
+  '🎉',
+  '✅',
+  '👀',
+  '💡',
+];
+
+export const CHAT_STICKERS: ChatSticker[] = [
+  {
+    id: 'spark',
+    label: 'Spark',
+    src: '/stickers/spark.svg',
+  },
+  {
+    id: 'heart',
+    label: 'Heart',
+    src: '/stickers/heart.svg',
+  },
+  {
+    id: 'thumbs-up',
+    label: 'Thumbs up',
+    src: '/stickers/thumbs-up.svg',
+  },
+  {
+    id: 'party',
+    label: 'Party',
+    src: '/stickers/party.svg',
+  },
+];
+
+export function findChatSticker(stickerId: string): ChatSticker | undefined {
+  return CHAT_STICKERS.find((sticker) => sticker.id === stickerId);
+}

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
@@ -3,7 +3,7 @@
   <div
     class="chat-header px-4 py-3 border-b font-semibold flex justify-between items-center"
   >
-    <span class="text-lg sm:text-xl">Chat with {{ username }}</span>
+    <span class="text-lg sm:text-xl">{{ chatTitle }}</span>
     <div class="flex items-center gap-2 flex-shrink-0">
       <button
         (click)="toggleSearch()"
@@ -87,7 +87,16 @@
           'search-active-match': isActiveSearchMatch(i),
         }"
       >
-        <div>{{ msg.content }}</div>
+        <ng-container [ngSwitch]="msg.kind">
+          <img
+            *ngSwitchCase="'sticker'"
+            class="chat-sticker"
+            [src]="msg.stickerSrc"
+            [alt]="msg.stickerLabel || msg.content"
+            loading="lazy"
+          />
+          <div *ngSwitchDefault>{{ msg.content }}</div>
+        </ng-container>
         <div class="message-time">
           {{ msg.timestamp | date: "shortTime" }}
         </div>
@@ -105,14 +114,76 @@
   </div>
 
   <!-- Input-Field -->
-  <form (submit)="sendMessage()" class="chat-input-row flex border-t px-4 py-3">
+  <form
+    (submit)="sendMessage()"
+    class="chat-input-row relative flex border-t px-4 py-3"
+  >
+    <div
+      *ngIf="isEmojiPickerOpen || isStickerPickerOpen"
+      class="reaction-popover"
+    >
+      <div
+        *ngIf="isEmojiPickerOpen"
+        class="emoji-grid"
+        aria-label="Emoji picker"
+      >
+        <button
+          *ngFor="let emoji of emojis"
+          type="button"
+          class="emoji-option"
+          (click)="insertEmoji(emoji)"
+          [attr.aria-label]="'Insert ' + emoji"
+        >
+          {{ emoji }}
+        </button>
+      </div>
+
+      <div
+        *ngIf="isStickerPickerOpen"
+        class="sticker-grid"
+        aria-label="Sticker picker"
+      >
+        <button
+          *ngFor="let sticker of stickers"
+          type="button"
+          class="sticker-option"
+          (click)="sendSticker(sticker)"
+          [attr.aria-label]="'Send ' + sticker.label + ' sticker'"
+        >
+          <img [src]="sticker.src" [alt]="sticker.label" loading="lazy" />
+        </button>
+      </div>
+    </div>
+
+    <button
+      type="button"
+      class="composer-tool-btn"
+      [class.is-active]="isEmojiPickerOpen"
+      (click)="toggleEmojiPicker()"
+      aria-label="Open emoji picker"
+      title="Emoji"
+    >
+      <i class="pi pi-face-smile"></i>
+    </button>
+    <button
+      type="button"
+      class="composer-tool-btn"
+      [class.is-active]="isStickerPickerOpen"
+      (click)="toggleStickerPicker()"
+      aria-label="Open sticker picker"
+      title="Stickers"
+    >
+      <i class="pi pi-image"></i>
+    </button>
     <input
+      #messageInput
       type="text"
       [(ngModel)]="newMessage"
       name="message"
-      class="chat-input flex-1 px-3 py-2 outline-none border rounded-l-md"
+      class="chat-input flex-1 px-3 py-2 outline-none border"
       placeholder="Type a message..."
       autocomplete="off"
+      (focus)="closeReactionPickers()"
     />
     <button
       type="submit"

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.scss
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.scss
@@ -161,6 +161,13 @@ button {
   letter-spacing: 0.01em;
 }
 
+.chat-sticker {
+  width: clamp(5.5rem, 24vw, 8.5rem);
+  aspect-ratio: 1;
+  display: block;
+  object-fit: contain;
+}
+
 .other-message {
   background: var(--chat-bubble-other-bg) !important;
   color: var(--color-text-primary) !important;
@@ -210,12 +217,16 @@ button {
 .chat-input-row {
   border-top-color: var(--color-border);
   background: var(--color-surface);
+  gap: 0.35rem;
+  align-items: stretch;
 }
 
 .chat-input {
   background: var(--color-input-bg);
   color: var(--color-text-primary);
   border-color: var(--color-input-border);
+  border-radius: 0.5rem 0 0 0.5rem;
+  min-width: 0;
 
   &:focus {
     border-color: var(--color-input-focus-border);
@@ -228,6 +239,100 @@ button {
   }
 }
 
+.composer-tool-btn {
+  width: 2.5rem;
+  min-width: 2.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  .pi {
+    font-size: 1rem;
+  }
+
+  &:hover,
+  &.is-active {
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+    background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+  }
+}
+
+.reaction-popover {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  bottom: calc(100% + 0.55rem);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  box-shadow: 0 14px 36px
+    color-mix(in srgb, var(--color-shadow-md) 60%, transparent);
+  padding: 0.7rem;
+  z-index: 2;
+}
+
+.emoji-grid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(2rem, 1fr));
+  gap: 0.35rem;
+}
+
+.emoji-option {
+  aspect-ratio: 1;
+  border-radius: 0.5rem;
+  border: 1px solid transparent;
+  background: transparent;
+  font-size: 1.35rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover,
+  &:focus-visible {
+    border-color: var(--color-border-hover);
+    background: var(--color-surface-hover);
+  }
+}
+
+.sticker-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(3.25rem, 1fr));
+  gap: 0.55rem;
+}
+
+.sticker-option {
+  aspect-ratio: 1;
+  border-radius: 0.65rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-background-secondary);
+  padding: 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  &:hover,
+  &:focus-visible {
+    border-color: var(--color-primary);
+    background: color-mix(
+      in srgb,
+      var(--color-primary) 8%,
+      var(--color-surface)
+    );
+  }
+}
+
 .send-btn {
   background: var(--chat-accent-bg);
   border: 1px solid var(--chat-accent-border);
@@ -235,9 +340,34 @@ button {
     color-mix(in srgb, var(--chat-accent-bg) 36%, transparent);
   color: #fff;
   min-width: 6rem;
+  border-radius: 0 0.5rem 0.5rem 0;
 
   &:hover {
     background: var(--chat-accent-hover);
     color: #fff;
+  }
+}
+
+@media (max-width: 520px) {
+  .chat-input-row {
+    padding-inline: 0.75rem !important;
+  }
+
+  .reaction-popover {
+    left: 0.75rem;
+    right: 0.75rem;
+  }
+
+  .emoji-grid {
+    grid-template-columns: repeat(4, minmax(2.4rem, 1fr));
+  }
+
+  .sticker-grid {
+    grid-template-columns: repeat(2, minmax(4.2rem, 1fr));
+  }
+
+  .send-btn {
+    min-width: 4.25rem;
+    padding-inline: 0.8rem !important;
   }
 }

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -20,11 +20,23 @@ import { Subscription } from 'rxjs/internal/Subscription';
 import { E2eeService } from '../../services/e2ee.service';
 import { DeviceDto } from '../../models/dtos/DeviceDto';
 import { UiToastService } from '../../core/services/ui-toast.service';
+import { GroupChatService } from '../../services/group-chat.service';
+import {
+  CHAT_EMOJIS,
+  CHAT_STICKERS,
+  ChatSticker,
+  findChatSticker,
+} from './chat-reactions';
 
 interface ChatMessageView {
+  kind: 'text' | 'sticker';
   content: string;
+  stickerId?: string;
+  stickerSrc?: string;
+  stickerLabel?: string;
   senderUsername?: string;
   privateChatId?: number;
+  groupId?: number | null;
   timestamp: string;
 }
 
@@ -33,6 +45,29 @@ interface EncryptedMessageBodyV1 {
   text: string;
   clientTimestamp?: string;
 }
+
+interface EncryptedTextMessageBodyV2 {
+  v: 2;
+  kind: 'text';
+  text: string;
+  clientTimestamp?: string;
+}
+
+interface EncryptedStickerMessageBodyV2 {
+  v: 2;
+  kind: 'sticker';
+  stickerId: string;
+  alt?: string;
+  clientTimestamp?: string;
+}
+
+type ParsedDecryptedMessageBody = {
+  kind: 'text' | 'sticker';
+  text: string | null;
+  stickerId: string | null;
+  stickerLabel: string | null;
+  clientTimestamp: string | null;
+};
 
 @Component({
   selector: 'app-private-chat-dialog',
@@ -46,7 +81,9 @@ export class PrivateChatDialogComponent
 {
   @Input() username!: string;
   @Input() currentUsername!: string | null;
-  @Input() privateChatId!: number;
+  @Input() privateChatId?: number;
+  @Input() groupId?: number;
+  @Input() chatMode: 'private' | 'group' = 'private';
   @Output() closeChat = new EventEmitter<void>();
 
   messages: ChatMessageView[] = [];
@@ -56,11 +93,12 @@ export class PrivateChatDialogComponent
   private readonly devicesCacheTtlMs = 15000;
 
   @ViewChild('messageContainer') messageContainer!: ElementRef<HTMLDivElement>;
+  @ViewChild('messageInput') messageInput?: ElementRef<HTMLInputElement>;
   @ViewChild('searchInput') searchInput?: ElementRef<HTMLInputElement>;
   @ViewChildren('messageBubble') messageBubbles!: QueryList<
     ElementRef<HTMLDivElement>
   >;
-  private privateMessageSub!: Subscription;
+  private messageSub?: Subscription;
 
   private shouldScroll = false;
   isSearchOpen = false;
@@ -68,39 +106,82 @@ export class PrivateChatDialogComponent
   matchedMessageIndexes: number[] = [];
   private matchedMessageIndexSet = new Set<number>();
   activeMatchPosition = -1;
+  readonly emojis = CHAT_EMOJIS;
+  readonly stickers = CHAT_STICKERS;
+  isEmojiPickerOpen = false;
+  isStickerPickerOpen = false;
 
   constructor(
     private wsService: WebSocketService,
     private chatService: PrivateChatService,
+    private groupChatService: GroupChatService,
     private e2eeService: E2eeService,
     private toast: UiToastService,
   ) {}
 
   ngOnInit(): void {
-    this.chatService.getMessages(this.privateChatId).subscribe({
-      next: (msgs) => {
-        this.decryptMessages(msgs);
-        this.shouldScroll = true;
-      },
-      error: () => {
-        console.error('Error loading messages for private chat');
-        this.toast.error('Chat load failed', 'Could not load messages.');
-      },
-    });
+    this.loadMessages();
 
-    this.privateMessageSub = this.wsService
-      .subscribeToPrivateMessages()
-      .subscribe((msg) => {
-        if (msg.privateChatId === this.privateChatId) {
-          this.decryptAndAppendMessage(msg);
-        }
-      });
+    this.messageSub = this.subscribeToActiveMessages();
 
     void this.initializeE2ee();
   }
 
   ngOnDestroy(): void {
-    this.privateMessageSub?.unsubscribe();
+    this.messageSub?.unsubscribe();
+  }
+
+  get chatTitle(): string {
+    return this.isGroupChat ? this.username : `Chat with ${this.username}`;
+  }
+
+  private get isGroupChat(): boolean {
+    return this.chatMode === 'group';
+  }
+
+  private get activeConversationId(): number | undefined {
+    return this.isGroupChat ? this.groupId : this.privateChatId;
+  }
+
+  private loadMessages(): void {
+    const conversationId = this.activeConversationId;
+    if (!conversationId) {
+      this.toast.error('Chat unavailable', 'Could not identify this chat.');
+      return;
+    }
+
+    const messages$ = this.isGroupChat
+      ? this.groupChatService.getMessages(conversationId)
+      : this.chatService.getMessages(conversationId);
+
+    messages$.subscribe({
+      next: (msgs) => {
+        this.decryptMessages(msgs);
+        this.shouldScroll = true;
+      },
+      error: () => {
+        console.error('Error loading messages for chat');
+        this.toast.error('Chat load failed', 'Could not load messages.');
+      },
+    });
+  }
+
+  private subscribeToActiveMessages(): Subscription {
+    if (this.isGroupChat && this.groupId) {
+      return this.wsService
+        .subscribeToGroupMessages(this.groupId)
+        .subscribe((msg) => {
+          if (msg.groupId === this.groupId) {
+            this.decryptAndAppendMessage(msg);
+          }
+        });
+    }
+
+    return this.wsService.subscribeToPrivateMessages().subscribe((msg) => {
+      if (msg.privateChatId === this.privateChatId) {
+        this.decryptAndAppendMessage(msg);
+      }
+    });
   }
 
   ngAfterViewChecked(): void {
@@ -122,7 +203,7 @@ export class PrivateChatDialogComponent
   sendMessage(): void {
     if (!this.newMessage.trim()) return;
 
-    void this.sendEncryptedMessage(this.newMessage);
+    void this.sendEncryptedTextMessage(this.newMessage);
   }
 
   onClose(): void {
@@ -151,7 +232,7 @@ export class PrivateChatDialogComponent
           console.error(
             'Failed to decrypt message in private chat',
             {
-              privateChatId: this.privateChatId,
+              conversationId: this.activeConversationId,
               messageIndex: index,
             },
             err,
@@ -166,7 +247,7 @@ export class PrivateChatDialogComponent
         );
         if (successfulMessages.length !== viewMessages.length) {
           console.warn('Some messages failed to decrypt for private chat', {
-            privateChatId: this.privateChatId,
+            conversationId: this.activeConversationId,
             totalMessages: viewMessages.length,
             decryptedMessages: successfulMessages.length,
           });
@@ -178,7 +259,7 @@ export class PrivateChatDialogComponent
       .catch((err) => {
         console.error(
           'Failed to decrypt one or more messages for private chat',
-          this.privateChatId,
+          this.activeConversationId,
           err,
         );
       });
@@ -193,7 +274,7 @@ export class PrivateChatDialogComponent
         if (!viewMessage) {
           console.warn(
             'Failed to decrypt incoming message for private chat',
-            this.privateChatId,
+            this.activeConversationId,
           );
           return;
         }
@@ -204,7 +285,7 @@ export class PrivateChatDialogComponent
       .catch((err) => {
         console.error(
           'Error decrypting incoming message for private chat',
-          this.privateChatId,
+          this.activeConversationId,
           err,
         );
       });
@@ -215,14 +296,26 @@ export class PrivateChatDialogComponent
   ): Promise<ChatMessageView | null> {
     let content = message.content ?? null;
     let timestamp = message.timestamp;
+    let kind: ChatMessageView['kind'] = 'text';
+    let stickerId: string | undefined;
+    let stickerSrc: string | undefined;
+    let stickerLabel: string | undefined;
+
     if (message.e2eePayload) {
       const decrypted = await this.e2eeService.decryptPayload(
         message.e2eePayload,
       );
       const parsed = this.parseDecryptedMessageBody(decrypted);
       content = parsed.text;
+      kind = parsed.kind;
       if (parsed.clientTimestamp) {
         timestamp = parsed.clientTimestamp;
+      }
+      if (parsed.kind === 'sticker' && parsed.stickerId) {
+        const sticker = findChatSticker(parsed.stickerId);
+        stickerId = parsed.stickerId;
+        stickerSrc = sticker?.src;
+        stickerLabel = parsed.stickerLabel ?? sticker?.label ?? 'Sticker';
       }
     }
     if (!content) {
@@ -230,15 +323,82 @@ export class PrivateChatDialogComponent
         ? 'Unable to decrypt message'
         : 'Encrypted message';
     }
+
     return {
+      kind: stickerSrc ? kind : 'text',
       content,
+      stickerId,
+      stickerSrc,
+      stickerLabel,
       senderUsername: message.senderUsername,
       privateChatId: message.privateChatId,
+      groupId: message.groupId,
       timestamp,
     };
   }
 
-  private async sendEncryptedMessage(plaintext: string): Promise<void> {
+  insertEmoji(emoji: string): void {
+    const input = this.messageInput?.nativeElement;
+    if (!input) {
+      this.newMessage += emoji;
+      return;
+    }
+
+    const start = input.selectionStart ?? this.newMessage.length;
+    const end = input.selectionEnd ?? start;
+    this.newMessage =
+      this.newMessage.slice(0, start) + emoji + this.newMessage.slice(end);
+    this.closeReactionPickers();
+
+    setTimeout(() => {
+      input.focus();
+      const cursorPosition = start + emoji.length;
+      input.setSelectionRange(cursorPosition, cursorPosition);
+    }, 0);
+  }
+
+  sendSticker(sticker: ChatSticker): void {
+    this.closeReactionPickers();
+    void this.sendEncryptedStickerMessage(sticker);
+  }
+
+  toggleEmojiPicker(): void {
+    this.isEmojiPickerOpen = !this.isEmojiPickerOpen;
+    this.isStickerPickerOpen = false;
+  }
+
+  toggleStickerPicker(): void {
+    this.isStickerPickerOpen = !this.isStickerPickerOpen;
+    this.isEmojiPickerOpen = false;
+  }
+
+  closeReactionPickers(): void {
+    this.isEmojiPickerOpen = false;
+    this.isStickerPickerOpen = false;
+  }
+
+  private async sendEncryptedTextMessage(plaintext: string): Promise<void> {
+    await this.sendEncryptedChatBody({
+      kind: 'text',
+      text: plaintext,
+    });
+  }
+
+  private async sendEncryptedStickerMessage(
+    sticker: ChatSticker,
+  ): Promise<void> {
+    await this.sendEncryptedChatBody({
+      kind: 'sticker',
+      stickerId: sticker.id,
+      alt: sticker.label,
+    });
+  }
+
+  private async sendEncryptedChatBody(
+    body:
+      | Omit<EncryptedTextMessageBodyV2, 'v' | 'clientTimestamp'>
+      | Omit<EncryptedStickerMessageBodyV2, 'v' | 'clientTimestamp'>,
+  ): Promise<void> {
     try {
       await this.e2eeService.ensureDeviceRegistered();
       this.devices = await this.fetchDevices();
@@ -258,9 +418,11 @@ export class PrivateChatDialogComponent
       }
 
       const clientTimestamp = new Date().toISOString();
-      const encryptedBody: EncryptedMessageBodyV1 = {
-        v: 1,
-        text: plaintext,
+      const encryptedBody:
+        | EncryptedTextMessageBodyV2
+        | EncryptedStickerMessageBodyV2 = {
+        v: 2,
+        ...body,
         clientTimestamp,
       };
       const payload = await this.e2eeService.encryptForDevices(
@@ -271,7 +433,8 @@ export class PrivateChatDialogComponent
       const message: ChatMessageDto = {
         timestamp: clientTimestamp,
         senderUsername: this.currentUsername ? this.currentUsername : 'Unknown',
-        privateChatId: this.privateChatId,
+        privateChatId: this.isGroupChat ? undefined : this.privateChatId,
+        groupId: this.isGroupChat ? this.groupId : null,
         senderDeviceId: payload.senderDeviceId,
         e2eePayload: JSON.stringify(payload),
       };
@@ -286,7 +449,9 @@ export class PrivateChatDialogComponent
         return;
       }
 
-      const sent = this.wsService.sendPrivateMessage(message);
+      const sent = this.isGroupChat
+        ? this.wsService.sendGroupMessage(message)
+        : this.wsService.sendPrivateMessage(message);
       if (!sent) {
         console.error('WebSocket not connected. Message not sent.');
         this.toast.error(
@@ -296,7 +461,9 @@ export class PrivateChatDialogComponent
         return;
       }
       this.decryptAndAppendMessage(message);
-      this.newMessage = '';
+      if (body.kind === 'text') {
+        this.newMessage = '';
+      }
     } catch (error) {
       console.error('Failed to send encrypted message', error);
       this.toast.error('Message failed', 'Could not send message.');
@@ -314,7 +481,17 @@ export class PrivateChatDialogComponent
       return Promise.resolve(this.devices);
     }
     return new Promise<DeviceDto[]>((resolve) => {
-      this.chatService.getDevices(this.privateChatId).subscribe({
+      const conversationId = this.activeConversationId;
+      if (!conversationId) {
+        resolve([]);
+        return;
+      }
+
+      const devices$ = this.isGroupChat
+        ? this.groupChatService.getDevices(conversationId)
+        : this.chatService.getDevices(conversationId);
+
+      devices$.subscribe({
         next: (devices) => {
           this.lastDevicesRefreshAt = Date.now();
           resolve(devices);
@@ -409,35 +586,100 @@ export class PrivateChatDialogComponent
     bubble.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }
 
-  private parseDecryptedMessageBody(decrypted: string | null): {
-    text: string | null;
-    clientTimestamp: string | null;
-  } {
+  private parseDecryptedMessageBody(
+    decrypted: string | null,
+  ): ParsedDecryptedMessageBody {
     if (!decrypted) {
-      return { text: null, clientTimestamp: null };
+      return this.emptyParsedMessage();
     }
 
     try {
-      const parsed = JSON.parse(decrypted) as Partial<EncryptedMessageBodyV1>;
+      const parsed = JSON.parse(decrypted) as Partial<
+        | EncryptedMessageBodyV1
+        | EncryptedTextMessageBodyV2
+        | EncryptedStickerMessageBodyV2
+      >;
       if (parsed.v === 1 && typeof parsed.text === 'string') {
         const timestamp =
           typeof parsed.clientTimestamp === 'string' &&
           !Number.isNaN(Date.parse(parsed.clientTimestamp))
             ? parsed.clientTimestamp
             : null;
-        return { text: parsed.text, clientTimestamp: timestamp };
+        return {
+          kind: 'text',
+          text: parsed.text,
+          stickerId: null,
+          stickerLabel: null,
+          clientTimestamp: timestamp,
+        };
+      }
+
+      if (
+        parsed.v === 2 &&
+        parsed.kind === 'text' &&
+        typeof parsed.text === 'string'
+      ) {
+        return {
+          kind: 'text',
+          text: parsed.text,
+          stickerId: null,
+          stickerLabel: null,
+          clientTimestamp: this.parseClientTimestamp(parsed.clientTimestamp),
+        };
+      }
+
+      if (
+        parsed.v === 2 &&
+        parsed.kind === 'sticker' &&
+        typeof parsed.stickerId === 'string'
+      ) {
+        const sticker = findChatSticker(parsed.stickerId);
+        const label =
+          typeof parsed.alt === 'string' && parsed.alt.trim()
+            ? parsed.alt
+            : (sticker?.label ?? 'Sticker');
+        return {
+          kind: 'sticker',
+          text: label,
+          stickerId: parsed.stickerId,
+          stickerLabel: label,
+          clientTimestamp: this.parseClientTimestamp(parsed.clientTimestamp),
+        };
       }
     } catch {
       // Backward compatibility for older messages that encrypted raw plaintext only.
     }
 
-    return { text: decrypted, clientTimestamp: null };
+    return {
+      kind: 'text',
+      text: decrypted,
+      stickerId: null,
+      stickerLabel: null,
+      clientTimestamp: null,
+    };
+  }
+
+  private emptyParsedMessage(): ParsedDecryptedMessageBody {
+    return {
+      kind: 'text',
+      text: null,
+      stickerId: null,
+      stickerLabel: null,
+      clientTimestamp: null,
+    };
+  }
+
+  private parseClientTimestamp(timestamp: string | undefined): string | null {
+    return typeof timestamp === 'string' && !Number.isNaN(Date.parse(timestamp))
+      ? timestamp
+      : null;
   }
 
   private isDuplicateMessage(message: ChatMessageDto): boolean {
     return this.messages.some(
       (existing) =>
         existing.privateChatId === message.privateChatId &&
+        existing.groupId === message.groupId &&
         existing.senderUsername === message.senderUsername &&
         existing.timestamp === message.timestamp,
     );

--- a/frontend/src/app/services/group-chat.service.ts
+++ b/frontend/src/app/services/group-chat.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { ChatMessageDto } from '../models/dtos/ChatMessageDto';
+import { DeviceDto } from '../models/dtos/DeviceDto';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GroupChatService {
+  private apiUrl = environment.mainApiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getMessages(groupId: number): Observable<ChatMessageDto[]> {
+    return this.http.get<ChatMessageDto[]>(
+      `${this.apiUrl}/groups/${groupId}/messages`,
+    );
+  }
+
+  getDevices(groupId: number): Observable<DeviceDto[]> {
+    return this.http.get<DeviceDto[]>(
+      `${this.apiUrl}/groups/${groupId}/devices`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Added E2EE-compatible emoji and bundled sticker support for private and group chats, including group chat history retrieval and shared chat rendering.

## Linked issue

Closes #205

## How to test

- `cd backend && .\mvnw clean test`
- `cd backend && .\mvnw spotless:check`
- `cd frontend && npm run build`
- `cd frontend && npx eslint "src/**/*.{ts,html}"`

## Notes / Risk

No database migration required. Stickers are bundled frontend assets referenced inside the encrypted payload; user-uploaded stickers are not included in this scope.