### PR TITLE
feat: Add realtime chat typing indicators with scoped WebSocket relay

### DIFF
--- a/backend/src/main/java/vaultWeb/config/websocket/TypingDisconnectListener.java
+++ b/backend/src/main/java/vaultWeb/config/websocket/TypingDisconnectListener.java
@@ -1,0 +1,18 @@
+package vaultWeb.config.websocket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import vaultWeb.services.TypingIndicatorService;
+
+@Component
+@RequiredArgsConstructor
+public class TypingDisconnectListener {
+  private final TypingIndicatorService typingIndicatorService;
+
+  @EventListener
+  public void onSessionDisconnect(SessionDisconnectEvent event) {
+    typingIndicatorService.handleDisconnect(event.getSessionId());
+  }
+}

--- a/backend/src/main/java/vaultWeb/controllers/TypingIndicatorController.java
+++ b/backend/src/main/java/vaultWeb/controllers/TypingIndicatorController.java
@@ -1,0 +1,24 @@
+package vaultWeb.controllers;
+
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+import vaultWeb.dtos.TypingIndicatorDto;
+import vaultWeb.services.TypingIndicatorService;
+
+@Controller
+@RequiredArgsConstructor
+public class TypingIndicatorController {
+  private final TypingIndicatorService typingIndicatorService;
+
+  @MessageMapping("/chat.typing")
+  public void typing(
+      @Payload TypingIndicatorDto event,
+      Principal principal,
+      @Header(name = "simpSessionId", required = false) String sessionId) {
+    typingIndicatorService.handleTypingEvent(event, principal, sessionId);
+  }
+}

--- a/backend/src/main/java/vaultWeb/dtos/TypingIndicatorDto.java
+++ b/backend/src/main/java/vaultWeb/dtos/TypingIndicatorDto.java
@@ -1,0 +1,12 @@
+package vaultWeb.dtos;
+
+import lombok.Data;
+
+@Data
+public class TypingIndicatorDto {
+  private String type;
+  private Long privateChatId;
+  private Long groupId;
+  private Long userId;
+  private String username;
+}

--- a/backend/src/main/java/vaultWeb/services/TypingIndicatorService.java
+++ b/backend/src/main/java/vaultWeb/services/TypingIndicatorService.java
@@ -45,6 +45,10 @@ public class TypingIndicatorService {
   private final Map<String, Set<TypingKey>> keysBySession = new ConcurrentHashMap<>();
 
   public void handleTypingEvent(TypingIndicatorDto event, Principal principal, String sessionId) {
+    if (event == null) {
+      throw new IllegalArgumentException("Typing event is required");
+    }
+
     if (principal == null || principal.getName() == null) {
       throw new AccessDeniedException("WebSocket user is not authenticated");
     }
@@ -56,7 +60,10 @@ public class TypingIndicatorService {
 
     if (TYPING_STOP.equals(event.getType())) {
       handleTypingStop(event, principal.getName(), sessionId);
+      return;
     }
+
+    throw new IllegalArgumentException("Unsupported typing event type");
   }
 
   public void handleDisconnect(String sessionId) {
@@ -201,8 +208,14 @@ public class TypingIndicatorService {
 
   private record TypingTarget(Long privateChatId, Long groupId, Set<String> recipientUsernames) {
     static TypingTarget privateChat(PrivateChat chat) {
-      return new TypingTarget(
-          chat.getId(), null, Set.of(chat.getUser1().getUsername(), chat.getUser2().getUsername()));
+      Set<String> recipients = ConcurrentHashMap.newKeySet();
+      if (chat.getUser1() != null && chat.getUser1().getUsername() != null) {
+        recipients.add(chat.getUser1().getUsername());
+      }
+      if (chat.getUser2() != null && chat.getUser2().getUsername() != null) {
+        recipients.add(chat.getUser2().getUsername());
+      }
+      return new TypingTarget(chat.getId(), null, recipients);
     }
 
     static TypingTarget group(Group group, Iterable<GroupMember> members) {

--- a/backend/src/main/java/vaultWeb/services/TypingIndicatorService.java
+++ b/backend/src/main/java/vaultWeb/services/TypingIndicatorService.java
@@ -1,0 +1,234 @@
+package vaultWeb.services;
+
+import java.security.Principal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import vaultWeb.dtos.TypingIndicatorDto;
+import vaultWeb.exceptions.notfound.GroupNotFoundException;
+import vaultWeb.exceptions.notfound.PrivateChatNotFoundException;
+import vaultWeb.exceptions.notfound.UserNotFoundException;
+import vaultWeb.models.Group;
+import vaultWeb.models.GroupMember;
+import vaultWeb.models.PrivateChat;
+import vaultWeb.models.User;
+import vaultWeb.repositories.GroupMemberRepository;
+import vaultWeb.repositories.GroupRepository;
+import vaultWeb.repositories.PrivateChatRepository;
+import vaultWeb.repositories.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class TypingIndicatorService {
+  public static final String TYPING_START = "typing_start";
+  public static final String TYPING_STOP = "typing_stop";
+
+  private static final Duration START_THROTTLE = Duration.ofSeconds(2);
+  private static final Duration STALE_TIMEOUT = Duration.ofSeconds(8);
+
+  private final SimpMessagingTemplate messagingTemplate;
+  private final UserRepository userRepository;
+  private final PrivateChatRepository privateChatRepository;
+  private final GroupRepository groupRepository;
+  private final GroupMemberRepository groupMemberRepository;
+
+  private final Map<TypingKey, Instant> activeTyping = new ConcurrentHashMap<>();
+  private final Map<TypingKey, Instant> lastStartByKey = new ConcurrentHashMap<>();
+  private final Map<String, Set<TypingKey>> keysBySession = new ConcurrentHashMap<>();
+
+  public void handleTypingEvent(TypingIndicatorDto event, Principal principal, String sessionId) {
+    if (principal == null || principal.getName() == null) {
+      throw new AccessDeniedException("WebSocket user is not authenticated");
+    }
+
+    if (TYPING_START.equals(event.getType())) {
+      handleTypingStart(event, principal.getName(), sessionId);
+      return;
+    }
+
+    if (TYPING_STOP.equals(event.getType())) {
+      handleTypingStop(event, principal.getName(), sessionId);
+    }
+  }
+
+  public void handleDisconnect(String sessionId) {
+    if (sessionId == null) {
+      return;
+    }
+
+    Set<TypingKey> keys = keysBySession.remove(sessionId);
+    if (keys == null) {
+      return;
+    }
+
+    keys.forEach(
+        key -> {
+          if (activeTyping.remove(key) != null) {
+            relayStop(key);
+          }
+        });
+  }
+
+  @Scheduled(fixedDelay = 1000)
+  void clearStaleTypingEntries() {
+    Instant now = Instant.now();
+    activeTyping.forEach(
+        (key, expiresAt) -> {
+          if (!expiresAt.isAfter(now) && activeTyping.remove(key, expiresAt)) {
+            removeKeyFromSessions(key);
+            relayStop(key);
+          }
+        });
+  }
+
+  private void handleTypingStart(TypingIndicatorDto event, String username, String sessionId) {
+    User sender = findUser(username);
+    TypingTarget target = resolveTarget(event, sender);
+    TypingKey key = TypingKey.from(target, sender);
+
+    Instant now = Instant.now();
+    Instant lastStart = lastStartByKey.get(key);
+    if (lastStart != null && Duration.between(lastStart, now).compareTo(START_THROTTLE) < 0) {
+      return;
+    }
+
+    lastStartByKey.put(key, now);
+    activeTyping.put(key, now.plus(STALE_TIMEOUT));
+    if (sessionId != null) {
+      keysBySession.computeIfAbsent(sessionId, ignored -> ConcurrentHashMap.newKeySet()).add(key);
+    }
+    relay(key, TYPING_START);
+  }
+
+  private void handleTypingStop(TypingIndicatorDto event, String username, String sessionId) {
+    User sender = findUser(username);
+    TypingTarget target = resolveTarget(event, sender);
+    TypingKey key = TypingKey.from(target, sender);
+
+    activeTyping.remove(key);
+    removeKeyFromSession(sessionId, key);
+    relayStop(key);
+  }
+
+  private User findUser(String username) {
+    return userRepository
+        .findByUsername(username)
+        .orElseThrow(() -> new UserNotFoundException("Typing sender not found"));
+  }
+
+  private TypingTarget resolveTarget(TypingIndicatorDto event, User sender) {
+    boolean hasPrivateChat = event.getPrivateChatId() != null;
+    boolean hasGroup = event.getGroupId() != null;
+
+    if (hasPrivateChat == hasGroup) {
+      throw new IllegalArgumentException("Typing event must target one private chat or one group");
+    }
+
+    if (hasPrivateChat) {
+      PrivateChat chat =
+          privateChatRepository
+              .findById(event.getPrivateChatId())
+              .orElseThrow(() -> new PrivateChatNotFoundException("Private chat not found"));
+      if (!isPrivateChatParticipant(chat, sender)) {
+        throw new AccessDeniedException("Not allowed to type in this private chat");
+      }
+      return TypingTarget.privateChat(chat);
+    }
+
+    Group group =
+        groupRepository
+            .findById(event.getGroupId())
+            .orElseThrow(() -> new GroupNotFoundException("Group not found"));
+    groupMemberRepository
+        .findByGroupIdAndUserId(group.getId(), sender.getId())
+        .orElseThrow(() -> new AccessDeniedException("Not allowed to type in this group"));
+    return TypingTarget.group(group, groupMemberRepository.findAllByGroup(group));
+  }
+
+  private boolean isPrivateChatParticipant(PrivateChat chat, User sender) {
+    return isSameUser(chat.getUser1(), sender) || isSameUser(chat.getUser2(), sender);
+  }
+
+  private boolean isSameUser(User left, User right) {
+    return left != null && right != null && Objects.equals(left.getId(), right.getId());
+  }
+
+  private void relayStop(TypingKey key) {
+    relay(key, TYPING_STOP);
+  }
+
+  private void relay(TypingKey key, String type) {
+    TypingIndicatorDto outbound = new TypingIndicatorDto();
+    outbound.setType(type);
+    outbound.setPrivateChatId(key.privateChatId());
+    outbound.setGroupId(key.groupId());
+    outbound.setUserId(key.userId());
+    outbound.setUsername(key.username());
+
+    key.recipientUsernames().stream()
+        .filter(recipient -> !recipient.equals(key.username()))
+        .forEach(
+            recipient ->
+                messagingTemplate.convertAndSendToUser(recipient, "/queue/typing", outbound));
+  }
+
+  private void removeKeyFromSession(String sessionId, TypingKey key) {
+    if (sessionId == null) {
+      return;
+    }
+
+    Set<TypingKey> keys = keysBySession.get(sessionId);
+    if (keys == null) {
+      return;
+    }
+    keys.remove(key);
+    if (keys.isEmpty()) {
+      keysBySession.remove(sessionId);
+    }
+  }
+
+  private void removeKeyFromSessions(TypingKey key) {
+    keysBySession.forEach((sessionId, ignored) -> removeKeyFromSession(sessionId, key));
+  }
+
+  private record TypingTarget(Long privateChatId, Long groupId, Set<String> recipientUsernames) {
+    static TypingTarget privateChat(PrivateChat chat) {
+      return new TypingTarget(
+          chat.getId(), null, Set.of(chat.getUser1().getUsername(), chat.getUser2().getUsername()));
+    }
+
+    static TypingTarget group(Group group, Iterable<GroupMember> members) {
+      Set<String> recipients = ConcurrentHashMap.newKeySet();
+      for (GroupMember member : members) {
+        if (member.getUser() != null && member.getUser().getUsername() != null) {
+          recipients.add(member.getUser().getUsername());
+        }
+      }
+      return new TypingTarget(null, group.getId(), recipients);
+    }
+  }
+
+  private record TypingKey(
+      Long privateChatId,
+      Long groupId,
+      Long userId,
+      String username,
+      Set<String> recipientUsernames) {
+    static TypingKey from(TypingTarget target, User user) {
+      return new TypingKey(
+          target.privateChatId(),
+          target.groupId(),
+          user.getId(),
+          user.getUsername(),
+          target.recipientUsernames());
+    }
+  }
+}

--- a/backend/src/test/java/vaultWeb/services/TypingIndicatorServiceTest.java
+++ b/backend/src/test/java/vaultWeb/services/TypingIndicatorServiceTest.java
@@ -1,0 +1,186 @@
+package vaultWeb.services;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.AccessDeniedException;
+import vaultWeb.dtos.TypingIndicatorDto;
+import vaultWeb.models.Group;
+import vaultWeb.models.GroupMember;
+import vaultWeb.models.PrivateChat;
+import vaultWeb.models.User;
+import vaultWeb.repositories.GroupMemberRepository;
+import vaultWeb.repositories.GroupRepository;
+import vaultWeb.repositories.PrivateChatRepository;
+import vaultWeb.repositories.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TypingIndicatorServiceTest {
+  @Mock private SimpMessagingTemplate messagingTemplate;
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private PrivateChatRepository privateChatRepository;
+
+  @Mock private GroupRepository groupRepository;
+
+  @Mock private GroupMemberRepository groupMemberRepository;
+
+  @InjectMocks private TypingIndicatorService typingIndicatorService;
+
+  private final Principal alicePrincipal = () -> "alice";
+
+  @Test
+  void shouldRelayPrivateTypingStartOnlyToOtherParticipant() {
+    User alice = user(1L, "alice");
+    User bob = user(2L, "bob");
+    PrivateChat chat = privateChat(10L, alice, bob);
+
+    when(userRepository.findByUsername("alice")).thenReturn(Optional.of(alice));
+    when(privateChatRepository.findById(10L)).thenReturn(Optional.of(chat));
+
+    typingIndicatorService.handleTypingEvent(
+        privateTyping(TypingIndicatorService.TYPING_START), alicePrincipal, "s1");
+
+    ArgumentCaptor<TypingIndicatorDto> captor = ArgumentCaptor.forClass(TypingIndicatorDto.class);
+    verify(messagingTemplate)
+        .convertAndSendToUser(eq("bob"), eq("/queue/typing"), captor.capture());
+    verify(messagingTemplate, never())
+        .convertAndSendToUser(eq("alice"), eq("/queue/typing"), any(TypingIndicatorDto.class));
+
+    TypingIndicatorDto sent = captor.getValue();
+    org.junit.jupiter.api.Assertions.assertEquals(
+        TypingIndicatorService.TYPING_START, sent.getType());
+    org.junit.jupiter.api.Assertions.assertEquals(10L, sent.getPrivateChatId());
+    org.junit.jupiter.api.Assertions.assertEquals(1L, sent.getUserId());
+    org.junit.jupiter.api.Assertions.assertEquals("alice", sent.getUsername());
+  }
+
+  @Test
+  void shouldDropRapidDuplicateTypingStarts() {
+    User alice = user(1L, "alice");
+    User bob = user(2L, "bob");
+    PrivateChat chat = privateChat(10L, alice, bob);
+
+    when(userRepository.findByUsername("alice")).thenReturn(Optional.of(alice));
+    when(privateChatRepository.findById(10L)).thenReturn(Optional.of(chat));
+
+    typingIndicatorService.handleTypingEvent(
+        privateTyping(TypingIndicatorService.TYPING_START), alicePrincipal, "s1");
+    typingIndicatorService.handleTypingEvent(
+        privateTyping(TypingIndicatorService.TYPING_START), alicePrincipal, "s1");
+
+    verify(messagingTemplate, times(1))
+        .convertAndSendToUser(eq("bob"), eq("/queue/typing"), any(TypingIndicatorDto.class));
+  }
+
+  @Test
+  void shouldRelayTypingStopOnDisconnect() {
+    User alice = user(1L, "alice");
+    User bob = user(2L, "bob");
+    PrivateChat chat = privateChat(10L, alice, bob);
+
+    when(userRepository.findByUsername("alice")).thenReturn(Optional.of(alice));
+    when(privateChatRepository.findById(10L)).thenReturn(Optional.of(chat));
+
+    typingIndicatorService.handleTypingEvent(
+        privateTyping(TypingIndicatorService.TYPING_START), alicePrincipal, "s1");
+    typingIndicatorService.handleDisconnect("s1");
+
+    ArgumentCaptor<TypingIndicatorDto> captor = ArgumentCaptor.forClass(TypingIndicatorDto.class);
+    verify(messagingTemplate, times(2))
+        .convertAndSendToUser(eq("bob"), eq("/queue/typing"), captor.capture());
+
+    org.junit.jupiter.api.Assertions.assertEquals(
+        TypingIndicatorService.TYPING_START, captor.getAllValues().get(0).getType());
+    org.junit.jupiter.api.Assertions.assertEquals(
+        TypingIndicatorService.TYPING_STOP, captor.getAllValues().get(1).getType());
+  }
+
+  @Test
+  void shouldRejectPrivateTypingWhenSenderIsNotParticipant() {
+    User alice = user(1L, "alice");
+    User bob = user(2L, "bob");
+    User carol = user(3L, "carol");
+    PrivateChat chat = privateChat(10L, bob, carol);
+
+    when(userRepository.findByUsername("alice")).thenReturn(Optional.of(alice));
+    when(privateChatRepository.findById(10L)).thenReturn(Optional.of(chat));
+
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            typingIndicatorService.handleTypingEvent(
+                privateTyping(TypingIndicatorService.TYPING_START), alicePrincipal, "s1"));
+  }
+
+  @Test
+  void shouldRelayGroupTypingToOtherMembers() {
+    User alice = user(1L, "alice");
+    User bob = user(2L, "bob");
+    User carol = user(3L, "carol");
+    Group group = new Group();
+    group.setId(20L);
+
+    when(userRepository.findByUsername("alice")).thenReturn(Optional.of(alice));
+    when(groupRepository.findById(20L)).thenReturn(Optional.of(group));
+    when(groupMemberRepository.findByGroupIdAndUserId(20L, 1L))
+        .thenReturn(Optional.of(new GroupMember(group, alice, null)));
+    when(groupMemberRepository.findAllByGroup(group))
+        .thenReturn(
+            List.of(
+                new GroupMember(group, alice, null),
+                new GroupMember(group, bob, null),
+                new GroupMember(group, carol, null)));
+
+    TypingIndicatorDto event = new TypingIndicatorDto();
+    event.setType(TypingIndicatorService.TYPING_START);
+    event.setGroupId(20L);
+
+    typingIndicatorService.handleTypingEvent(event, alicePrincipal, "s1");
+
+    verify(messagingTemplate)
+        .convertAndSendToUser(eq("bob"), eq("/queue/typing"), any(TypingIndicatorDto.class));
+    verify(messagingTemplate)
+        .convertAndSendToUser(eq("carol"), eq("/queue/typing"), any(TypingIndicatorDto.class));
+    verify(messagingTemplate, never())
+        .convertAndSendToUser(eq("alice"), eq("/queue/typing"), any(TypingIndicatorDto.class));
+  }
+
+  private TypingIndicatorDto privateTyping(String type) {
+    TypingIndicatorDto event = new TypingIndicatorDto();
+    event.setType(type);
+    event.setPrivateChatId(10L);
+    return event;
+  }
+
+  private User user(Long id, String username) {
+    User user = new User();
+    user.setId(id);
+    user.setUsername(username);
+    return user;
+  }
+
+  private PrivateChat privateChat(Long id, User user1, User user2) {
+    PrivateChat chat = new PrivateChat();
+    chat.setId(id);
+    chat.setUser1(user1);
+    chat.setUser2(user2);
+    return chat;
+  }
+}

--- a/backend/src/test/java/vaultWeb/services/TypingIndicatorServiceTest.java
+++ b/backend/src/test/java/vaultWeb/services/TypingIndicatorServiceTest.java
@@ -130,6 +130,22 @@ class TypingIndicatorServiceTest {
   }
 
   @Test
+  void shouldRejectMissingTypingEventPayload() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> typingIndicatorService.handleTypingEvent(null, alicePrincipal, "s1"));
+  }
+
+  @Test
+  void shouldRejectUnsupportedTypingEventType() {
+    TypingIndicatorDto event = privateTyping("typing_pause");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> typingIndicatorService.handleTypingEvent(event, alicePrincipal, "s1"));
+  }
+
+  @Test
   void shouldRelayGroupTypingToOtherMembers() {
     User alice = user(1L, "alice");
     User bob = user(2L, "bob");

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -74,7 +74,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
+            "polyfills": ["zone.js", "zone.js/testing", "src/polyfills.ts"],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [

--- a/frontend/src/app/models/dtos/TypingIndicatorDto.ts
+++ b/frontend/src/app/models/dtos/TypingIndicatorDto.ts
@@ -1,0 +1,7 @@
+export interface TypingIndicatorDto {
+  type: 'typing_start' | 'typing_stop';
+  privateChatId?: number | null;
+  groupId?: number | null;
+  userId?: number;
+  username?: string;
+}

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
@@ -102,6 +102,10 @@
     >
       No messages found for '{{ searchQuery }}'
     </div>
+
+    <div *ngIf="typingIndicatorLabel" class="typing-indicator text-sm">
+      {{ typingIndicatorLabel }}
+    </div>
   </div>
 
   <!-- Input-Field -->
@@ -109,6 +113,7 @@
     <input
       type="text"
       [(ngModel)]="newMessage"
+      (ngModelChange)="onComposerInput($event)"
       name="message"
       class="chat-input flex-1 px-3 py-2 outline-none border rounded-l-md"
       placeholder="Type a message..."

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.scss
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.scss
@@ -207,6 +207,12 @@ button {
   color: var(--color-text-muted);
 }
 
+.typing-indicator {
+  color: var(--color-text-muted);
+  min-height: 1.25rem;
+  padding: 0.25rem 0.15rem 0;
+}
+
 .chat-input-row {
   border-top-color: var(--color-border);
   background: var(--color-surface);

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.spec.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.spec.ts
@@ -1,0 +1,123 @@
+import {
+  ComponentFixture,
+  TestBed,
+  discardPeriodicTasks,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import { of, Subject } from 'rxjs';
+import { UiToastService } from '../../core/services/ui-toast.service';
+import { ChatMessageDto } from '../../models/dtos/ChatMessageDto';
+import { TypingIndicatorDto } from '../../models/dtos/TypingIndicatorDto';
+import { DeviceDto } from '../../models/dtos/DeviceDto';
+import { E2eeService } from '../../services/e2ee.service';
+import { PrivateChatService } from '../../services/private-chat.service';
+import { WebSocketService } from '../../services/web-socket.service';
+import { PrivateChatDialogComponent } from './private-chat-dialog.component';
+
+describe('PrivateChatDialogComponent typing indicators', () => {
+  let fixture: ComponentFixture<PrivateChatDialogComponent>;
+  let component: PrivateChatDialogComponent;
+  let typingEvents: Subject<TypingIndicatorDto>;
+  let wsService: jasmine.SpyObj<WebSocketService>;
+
+  beforeEach(async () => {
+    typingEvents = new Subject<TypingIndicatorDto>();
+    wsService = jasmine.createSpyObj<WebSocketService>('WebSocketService', [
+      'subscribeToPrivateMessages',
+      'subscribeToTypingIndicators',
+      'sendTypingIndicator',
+      'ensureConnected',
+      'sendPrivateMessage',
+    ]);
+    wsService.subscribeToPrivateMessages.and.returnValue(of<ChatMessageDto>());
+    wsService.subscribeToTypingIndicators.and.returnValue(
+      typingEvents.asObservable(),
+    );
+    wsService.sendTypingIndicator.and.returnValue(true);
+    wsService.ensureConnected.and.resolveTo(true);
+    wsService.sendPrivateMessage.and.returnValue(true);
+
+    const chatService = jasmine.createSpyObj<PrivateChatService>(
+      'PrivateChatService',
+      ['getMessages', 'getDevices'],
+    );
+    chatService.getMessages.and.returnValue(of([]));
+    chatService.getDevices.and.returnValue(of<DeviceDto[]>([]));
+
+    const e2eeService = jasmine.createSpyObj<E2eeService>('E2eeService', [
+      'ensureDeviceRegistered',
+      'encryptForDevices',
+      'decryptPayload',
+    ]);
+    e2eeService.ensureDeviceRegistered.and.resolveTo();
+
+    const toast = jasmine.createSpyObj<UiToastService>('UiToastService', [
+      'error',
+      'warn',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [PrivateChatDialogComponent],
+      providers: [
+        { provide: WebSocketService, useValue: wsService },
+        { provide: PrivateChatService, useValue: chatService },
+        { provide: E2eeService, useValue: e2eeService },
+        { provide: UiToastService, useValue: toast },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PrivateChatDialogComponent);
+    component = fixture.componentInstance;
+    component.username = 'bob';
+    component.currentUsername = 'alice';
+    component.privateChatId = 10;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('emits one typing start while active and a stop after local idle timeout', fakeAsync(() => {
+    component.onComposerInput('h');
+    component.onComposerInput('he');
+    component.onComposerInput('hel');
+
+    expect(wsService.sendTypingIndicator).toHaveBeenCalledTimes(1);
+    expect(wsService.sendTypingIndicator).toHaveBeenCalledWith({
+      type: 'typing_start',
+      privateChatId: 10,
+      groupId: null,
+    });
+
+    tick(5000);
+
+    expect(wsService.sendTypingIndicator).toHaveBeenCalledTimes(2);
+    expect(wsService.sendTypingIndicator).toHaveBeenCalledWith({
+      type: 'typing_stop',
+      privateChatId: 10,
+      groupId: null,
+    });
+    discardPeriodicTasks();
+  }));
+
+  it('shows and clears incoming typing indicators for the active private chat', fakeAsync(() => {
+    typingEvents.next({
+      type: 'typing_start',
+      privateChatId: 10,
+      username: 'bob',
+    });
+
+    expect(component.typingIndicatorLabel).toBe('bob is typing...');
+
+    typingEvents.next({
+      type: 'typing_stop',
+      privateChatId: 10,
+      username: 'bob',
+    });
+
+    expect(component.typingIndicatorLabel).toBe('');
+    discardPeriodicTasks();
+  }));
+});

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -14,6 +14,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ChatMessageDto } from '../../models/dtos/ChatMessageDto';
+import { TypingIndicatorDto } from '../../models/dtos/TypingIndicatorDto';
 import { WebSocketService } from '../../services/web-socket.service';
 import { PrivateChatService } from '../../services/private-chat.service';
 import { Subscription } from 'rxjs/internal/Subscription';
@@ -61,6 +62,7 @@ export class PrivateChatDialogComponent
     ElementRef<HTMLDivElement>
   >;
   private privateMessageSub!: Subscription;
+  private typingIndicatorSub!: Subscription;
 
   private shouldScroll = false;
   isSearchOpen = false;
@@ -68,6 +70,12 @@ export class PrivateChatDialogComponent
   matchedMessageIndexes: number[] = [];
   private matchedMessageIndexSet = new Set<number>();
   activeMatchPosition = -1;
+  private isTyping = false;
+  private typingIdleTimer: ReturnType<typeof setTimeout> | null = null;
+  private typingStaleSweepTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly typingIdleTimeoutMs = 5000;
+  private readonly typingStaleTimeoutMs = 8000;
+  private readonly typingUsers = new Map<string, number>();
 
   constructor(
     private wsService: WebSocketService,
@@ -96,11 +104,22 @@ export class PrivateChatDialogComponent
         }
       });
 
+    this.typingIndicatorSub = this.wsService
+      .subscribeToTypingIndicators()
+      .subscribe((event) => this.handleTypingIndicator(event));
+    this.typingStaleSweepTimer = setInterval(
+      () => this.removeStaleTypingUsers(),
+      2000,
+    );
+
     void this.initializeE2ee();
   }
 
   ngOnDestroy(): void {
+    this.stopTyping();
     this.privateMessageSub?.unsubscribe();
+    this.typingIndicatorSub?.unsubscribe();
+    this.clearTypingTimers();
   }
 
   ngAfterViewChecked(): void {
@@ -122,11 +141,45 @@ export class PrivateChatDialogComponent
   sendMessage(): void {
     if (!this.newMessage.trim()) return;
 
+    this.stopTyping();
     void this.sendEncryptedMessage(this.newMessage);
   }
 
   onClose(): void {
+    this.stopTyping();
     this.closeChat.emit();
+  }
+
+  onComposerInput(value: string): void {
+    if (!value.trim()) {
+      this.stopTyping();
+      return;
+    }
+
+    if (!this.isTyping) {
+      this.isTyping = true;
+      this.sendTypingEvent('typing_start');
+    }
+
+    this.resetTypingIdleTimer();
+  }
+
+  get typingIndicatorLabel(): string {
+    const names = Array.from(this.typingUsers.keys());
+
+    if (names.length === 0) {
+      return '';
+    }
+
+    if (names.length === 1) {
+      return `${names[0]} is typing...`;
+    }
+
+    if (names.length === 2) {
+      return `${names[0]} and ${names[1]} are typing...`;
+    }
+
+    return 'Several people are typing...';
   }
 
   private async initializeE2ee(): Promise<void> {
@@ -198,6 +251,9 @@ export class PrivateChatDialogComponent
           return;
         }
         this.messages.push(viewMessage);
+        if (viewMessage.senderUsername !== this.currentUsername) {
+          this.typingUsers.delete(viewMessage.senderUsername ?? '');
+        }
         this.applySearch();
         this.shouldScroll = !this.searchQuery.trim();
       })
@@ -441,5 +497,79 @@ export class PrivateChatDialogComponent
         existing.senderUsername === message.senderUsername &&
         existing.timestamp === message.timestamp,
     );
+  }
+
+  private handleTypingIndicator(event: TypingIndicatorDto): void {
+    if (
+      event.privateChatId !== this.privateChatId ||
+      !event.username ||
+      event.username === this.currentUsername
+    ) {
+      return;
+    }
+
+    if (event.type === 'typing_start') {
+      this.typingUsers.set(
+        event.username,
+        Date.now() + this.typingStaleTimeoutMs,
+      );
+      return;
+    }
+
+    if (event.type === 'typing_stop') {
+      this.typingUsers.delete(event.username);
+    }
+  }
+
+  private resetTypingIdleTimer(): void {
+    if (this.typingIdleTimer) {
+      clearTimeout(this.typingIdleTimer);
+    }
+    this.typingIdleTimer = setTimeout(
+      () => this.stopTyping(),
+      this.typingIdleTimeoutMs,
+    );
+  }
+
+  private stopTyping(): void {
+    if (this.typingIdleTimer) {
+      clearTimeout(this.typingIdleTimer);
+      this.typingIdleTimer = null;
+    }
+
+    if (!this.isTyping) {
+      return;
+    }
+
+    this.isTyping = false;
+    this.sendTypingEvent('typing_stop');
+  }
+
+  private sendTypingEvent(type: TypingIndicatorDto['type']): void {
+    this.wsService.sendTypingIndicator({
+      type,
+      privateChatId: this.privateChatId,
+      groupId: null,
+    });
+  }
+
+  private removeStaleTypingUsers(): void {
+    const now = Date.now();
+    Array.from(this.typingUsers.entries()).forEach(([username, expiresAt]) => {
+      if (expiresAt <= now) {
+        this.typingUsers.delete(username);
+      }
+    });
+  }
+
+  private clearTypingTimers(): void {
+    if (this.typingIdleTimer) {
+      clearTimeout(this.typingIdleTimer);
+      this.typingIdleTimer = null;
+    }
+    if (this.typingStaleSweepTimer) {
+      clearInterval(this.typingStaleSweepTimer);
+      this.typingStaleSweepTimer = null;
+    }
   }
 }

--- a/frontend/src/app/services/web-socket.service.ts
+++ b/frontend/src/app/services/web-socket.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 import { ChatMessageDto } from '../models/dtos/ChatMessageDto';
+import { TypingIndicatorDto } from '../models/dtos/TypingIndicatorDto';
 import { environment } from '../../environments/environment';
 import { AuthService } from './auth.service';
 import { Observable, Observer } from 'rxjs';
@@ -151,6 +152,19 @@ export class WebSocketService {
     }
   }
 
+  sendTypingIndicator(event: TypingIndicatorDto): boolean {
+    if (this.connected) {
+      this.client?.publish({
+        destination: '/app/chat.typing',
+        body: JSON.stringify(event),
+      });
+      return true;
+    } else {
+      console.warn('WebSocket not connected yet. Typing indicator not sent.');
+      return false;
+    }
+  }
+
   subscribeToPrivateMessages(): Observable<ChatMessageDto> {
     return new Observable((observer) => {
       const subscribeAction = () => {
@@ -193,6 +207,54 @@ export class WebSocketService {
       (message) => {
         const msg = JSON.parse(message.body) as ChatMessageDto;
         observer.next(msg);
+      },
+    );
+
+    return () => subscription?.unsubscribe();
+  }
+
+  subscribeToTypingIndicators(): Observable<TypingIndicatorDto> {
+    return new Observable((observer) => {
+      const subscribeAction = () => {
+        return this.subscribeToTypingInternal(observer);
+      };
+
+      let unsubscribeFn: (() => void) | undefined;
+      let isUnsubscribed = false;
+      let queuedSubscribe: (() => void) | undefined;
+
+      if (!this.connected) {
+        queuedSubscribe = () => {
+          if (isUnsubscribed) {
+            return;
+          }
+          unsubscribeFn = subscribeAction();
+        };
+        this.connectCallbacks.push(queuedSubscribe);
+      } else {
+        unsubscribeFn = subscribeAction();
+      }
+
+      return () => {
+        isUnsubscribed = true;
+        if (!unsubscribeFn && queuedSubscribe) {
+          this.connectCallbacks = this.connectCallbacks.filter(
+            (cb) => cb !== queuedSubscribe,
+          );
+        }
+        if (unsubscribeFn) {
+          unsubscribeFn();
+        }
+      };
+    });
+  }
+
+  private subscribeToTypingInternal(observer: Observer<TypingIndicatorDto>) {
+    const subscription = this.client?.subscribe(
+      '/user/queue/typing',
+      (message) => {
+        const event = JSON.parse(message.body) as TypingIndicatorDto;
+        observer.next(event);
       },
     );
 

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "outDir": "./out-tsc/spec",
     "types": ["jasmine"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts", "src/polyfills.ts"]
 }


### PR DESCRIPTION
## Summary

Implemented realtime chat typing indicators for private chat using the existing STOMP/SockJS WebSocket transport.

Backend changes:
- Added ephemeral typing indicator DTO and WebSocket handler for `/app/chat.typing`.
- Added server-side relay through `/user/queue/typing`.
- Added authenticated sender derivation from the WebSocket principal instead of trusting client-supplied user identity.
- Added private chat and group target support via `privateChatId` / `groupId`.
- Added membership validation before relaying typing events.
- Added per-user/per-conversation throttling for `typing_start` events.
- Added server-side stale cleanup for typing state after inactivity.
- Added disconnect cleanup that emits synthetic `typing_stop` behavior for active typing sessions.
- Kept typing state fully ephemeral; nothing is persisted to the database or added to the E2EE message pipeline.

Frontend changes:
- Added `TypingIndicatorDto`.
- Added WebSocket service methods for sending and subscribing to typing indicators.
- Wired private chat composer input to emit `typing_start` only on idle-to-typing transition.
- Added 5s local idle timeout to emit `typing_stop`.
- Emits `typing_stop` on send, close, and component destroy.
- Added receiver-side stale cleanup for dropped/missed stop events.
- Renders typing indicator text below the message list.
- Added name formatting support:
  - 1 user: `Alice is typing...`
  - 2 users: `Alice and Bob are typing...`
  - 3+ users: `Several people are typing...`

Testing/config changes:
- Added backend unit coverage for relay, authorization, throttling, group fanout, and disconnect cleanup.
- Added frontend component spec for typing debounce/start-stop behavior and incoming indicator display.
- Fixed Karma test environment by loading `src/polyfills.ts` in the test target and including it in `tsconfig.spec.json`, resolving `global is not defined`.

## Linked issue

Closes #156

## How to test

Backend:
- Run focused typing tests:

```bash
cd backend
./mvnw -Dtest=TypingIndicatorServiceTest test
```

- Run full backend tests:

```bash
cd backend
./mvnw test
```

- Check Java formatting:

```bash
cd backend
./mvnw spotless:check
```

Frontend:
- Run the full Karma suite:

```bash
cd frontend
npx ng test --watch=false --browsers=ChromeHeadless --progress=false
```

Expected result:

```text
TOTAL: 4 SUCCESS
```

- Type-check specs:

```bash
cd frontend
npx tsc -p tsconfig.spec.json --noEmit
```

- Build the app:

```bash
cd frontend
npm run build
```

- Lint:

```bash
cd frontend
npx eslint "src/**/*.{ts,html}"
```

Manual test:
- Open two browsers with two different users in the same private chat.
- Start typing from user A.
- Confirm user B sees `Alice is typing...`.
- Stop typing and wait about 5 seconds.
- Confirm the indicator clears.
- Start typing again and send a message.
- Confirm the indicator clears immediately on send.
- Close the chat while typing.
- Confirm the other user does not keep seeing a stale typing indicator.
- Optionally kill/reload the typing user’s tab and confirm stale state clears via disconnect/stale cleanup.

## Notes / Risk

- No database migration required.
- Typing indicators are intentionally ephemeral and are not persisted.
- Typing indicators are not encrypted and are not part of the E2EE message payload flow.
- Backend derives sender identity from the authenticated WebSocket principal.
- Client-supplied `userId` / `username` is not trusted for relay identity.
- Current visible UI wiring is for private chat, because that is the existing chat surface in the frontend.
- Backend service supports both private chat and group typing targets, but group UI wiring may need a separate follow-up if/when group chat UI is expanded.
- `typing_start` events are throttled server-side to reduce relay spam from buggy/malicious clients.
- Receiver-side stale cleanup exists as a fallback in case `typing_stop` is missed.
- Server-side stale cleanup exists as a fallback for crashed/disconnected clients.
- Karma test config now includes `src/polyfills.ts` because the test bundle also needs the `window.global` polyfill used by dependencies.
- Existing build warnings remain:
  - component stylesheet budget warnings
  - `sockjs-client` CommonJS warning
  - existing lint warnings in `auth.guard.ts` for unused route/state parameters.