### PR TITLE
Bump spring-boot-starter-parent to 3.5.16 to fix multiple CVEs

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.7</version>
+        <version>3.5.16</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Backend was pinned to spring-boot-starter-parent 3.5.7, which transitively manages vulnerable versions of Spring Security, Spring Boot Actuator, and the Postgres JDBC driver:

- CVE-2026-22732 (CRITICAL): spring-security-web policy bypass / info disclosure, fixed in 6.5.9
- CVE-2026-22731 / CVE-2026-22733 (HIGH): Actuator authentication bypass via Health Group / CloudFoundry endpoints, fixed in 3.5.12
- CVE-2026-42198 (HIGH): pgjdbc client-side DoS via malicious SCRAM-SHA-256 auth, fixed in 42.7.11
- CVE-2026-47838 (MEDIUM): spring-security X.509 client cert impersonation, fixed in 6.5.11
- CVE-2026-22751 (MEDIUM): spring-security-core race condition auth bypass, fixed in 6.5.10
- CVE-2026-40973: Spring Boot arbitrary code execution / session hijacking, fixed in 3.5.14

3.5.16 is the latest available 3.5.x patch and pins fixed versions of all of the above (spring-security 6.5.11, postgresql 42.7.11).

Fixes #220

## Summary

<!-- what changed? -->

## Linked issue

Closes #

## How to test

## Notes / Risk

<!-- migrations, flags, rollout, anything risky -->
