### PR TITLE
feat(cloud): add tooltips and aria-labels to icon-only action buttons

### DIFF
--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -212,9 +212,10 @@
                 [loading]="isDownloading(entry.path)"
                 [disabled]="isDownloading(entry.path)"
                 (click)="downloadFileByPath(entry.path, entry.name)"
-                pTooltip="Download"
+                pTooltip="Download file"
                 tooltipPosition="top"
                 ariaLabel="Download file"
+                aria-label="Download file"
               ></p-button>
               <p-button
                 icon="pi pi-pencil"
@@ -224,8 +225,13 @@
                     ? openRenameFolderDialog(entry.path, entry.name)
                     : onEditAction(entry.path, entry.name)
                 "
-                [pTooltip]="entry.kind === 'folder' ? 'Rename' : 'Edit'"
+                [pTooltip]="
+                  entry.kind === 'folder' ? 'Rename folder' : 'Edit file'
+                "
                 tooltipPosition="top"
+                [ariaLabel]="
+                  entry.kind === 'folder' ? 'Rename folder' : 'Edit file'
+                "
                 [attr.aria-label]="
                   entry.kind === 'folder' ? 'Rename folder' : 'Edit file'
                 "
@@ -239,8 +245,13 @@
                     ? confirmDeleteFolder(entry.path)
                     : confirmDeleteFile(entry.path)
                 "
-                pTooltip="Delete"
+                [pTooltip]="
+                  entry.kind === 'folder' ? 'Delete folder' : 'Delete file'
+                "
                 tooltipPosition="top"
+                [ariaLabel]="
+                  entry.kind === 'folder' ? 'Delete folder' : 'Delete file'
+                "
                 [attr.aria-label]="
                   entry.kind === 'folder' ? 'Delete folder' : 'Delete file'
                 "

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -215,7 +215,6 @@
                 pTooltip="Download file"
                 tooltipPosition="top"
                 ariaLabel="Download file"
-                aria-label="Download file"
               ></p-button>
               <p-button
                 icon="pi pi-pencil"
@@ -230,9 +229,6 @@
                 "
                 tooltipPosition="top"
                 [ariaLabel]="
-                  entry.kind === 'folder' ? 'Rename folder' : 'Edit file'
-                "
-                [attr.aria-label]="
                   entry.kind === 'folder' ? 'Rename folder' : 'Edit file'
                 "
               ></p-button>
@@ -250,9 +246,6 @@
                 "
                 tooltipPosition="top"
                 [ariaLabel]="
-                  entry.kind === 'folder' ? 'Delete folder' : 'Delete file'
-                "
-                [attr.aria-label]="
                   entry.kind === 'folder' ? 'Delete folder' : 'Delete file'
                 "
               ></p-button>

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -212,6 +212,9 @@
                 [loading]="isDownloading(entry.path)"
                 [disabled]="isDownloading(entry.path)"
                 (click)="downloadFileByPath(entry.path, entry.name)"
+                pTooltip="Download"
+                tooltipPosition="top"
+                ariaLabel="Download file"
               ></p-button>
               <p-button
                 icon="pi pi-pencil"
@@ -220,6 +223,11 @@
                   entry.kind === 'folder'
                     ? openRenameFolderDialog(entry.path, entry.name)
                     : onEditAction(entry.path, entry.name)
+                "
+                [pTooltip]="entry.kind === 'folder' ? 'Rename' : 'Edit'"
+                tooltipPosition="top"
+                [attr.aria-label]="
+                  entry.kind === 'folder' ? 'Rename folder' : 'Edit file'
                 "
               ></p-button>
               <p-button
@@ -230,6 +238,11 @@
                   entry.kind === 'folder'
                     ? confirmDeleteFolder(entry.path)
                     : confirmDeleteFile(entry.path)
+                "
+                pTooltip="Delete"
+                tooltipPosition="top"
+                [attr.aria-label]="
+                  entry.kind === 'folder' ? 'Delete folder' : 'Delete file'
                 "
               ></p-button>
             </div>

--- a/frontend/src/app/pages/cloud/trash/trash.component.html
+++ b/frontend/src/app/pages/cloud/trash/trash.component.html
@@ -66,6 +66,8 @@
                 [loading]="isProcessing(entry.id)"
                 [disabled]="isProcessing(entry.id)"
                 (click)="restore(entry)"
+                pTooltip="Restore to original location"
+                tooltipPosition="top"
               ></p-button>
               <p-button
                 icon="pi pi-trash"
@@ -74,6 +76,8 @@
                 styleClass="p-button-rounded p-button-text p-button-sm"
                 [disabled]="isProcessing(entry.id)"
                 (click)="confirmPurge(entry)"
+                pTooltip="Delete permanently"
+                tooltipPosition="top"
               ></p-button>
             </div>
           </td>

--- a/frontend/src/app/pages/cloud/trash/trash.component.html
+++ b/frontend/src/app/pages/cloud/trash/trash.component.html
@@ -69,7 +69,6 @@
                 pTooltip="Restore to original location"
                 tooltipPosition="top"
                 ariaLabel="Restore to original location"
-                aria-label="Restore to original location"
               ></p-button>
               <p-button
                 icon="pi pi-trash"
@@ -80,7 +79,6 @@
                 pTooltip="Delete permanently"
                 tooltipPosition="top"
                 ariaLabel="Delete permanently"
-                aria-label="Delete permanently"
               ></p-button>
             </div>
           </td>

--- a/frontend/src/app/pages/cloud/trash/trash.component.html
+++ b/frontend/src/app/pages/cloud/trash/trash.component.html
@@ -68,16 +68,19 @@
                 (click)="restore(entry)"
                 pTooltip="Restore to original location"
                 tooltipPosition="top"
+                ariaLabel="Restore to original location"
+                aria-label="Restore to original location"
               ></p-button>
               <p-button
                 icon="pi pi-trash"
                 severity="danger"
-                ariaLabel="Delete permanently"
                 styleClass="p-button-rounded p-button-text p-button-sm"
                 [disabled]="isProcessing(entry.id)"
                 (click)="confirmPurge(entry)"
                 pTooltip="Delete permanently"
                 tooltipPosition="top"
+                ariaLabel="Delete permanently"
+                aria-label="Delete permanently"
               ></p-button>
             </div>
           </td>

--- a/frontend/src/app/pages/cloud/trash/trash.component.ts
+++ b/frontend/src/app/pages/cloud/trash/trash.component.ts
@@ -5,6 +5,7 @@ import { ConfirmationService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TableModule } from 'primeng/table';
+import { TooltipModule } from 'primeng/tooltip';
 import { finalize } from 'rxjs';
 import { TrashEntryDto } from '../../../models/dtos/TrashEntryDto';
 import { CloudService } from '../../../services/cloud.service';
@@ -13,7 +14,13 @@ import { UiToastService } from '../../../core/services/ui-toast.service';
 @Component({
   selector: 'app-trash',
   standalone: true,
-  imports: [CommonModule, TableModule, ButtonModule, ConfirmDialogModule],
+  imports: [
+    CommonModule,
+    TableModule,
+    ButtonModule,
+    ConfirmDialogModule,
+    TooltipModule,
+  ],
   providers: [ConfirmationService],
   templateUrl: './trash.component.html',
   styleUrls: ['./trash.component.scss'],


### PR DESCRIPTION
## Summary

Improves the Cloud and Trash pages by adding `pTooltip` and `aria-label` attributes to all icon-only action buttons, completing the UI polish pass that replaced emoji icons with PrimeNG icons and ensured all HTTP errors use dismissible toast notifications.

## Problem

The Cloud page's icon-only action buttons (Download, Edit/Rename, Delete) lacked hover tooltips and screen-reader labels. Users had to guess what each icon did — especially problematic for the pencil icon which means "Edit" for files but "Rename" for folders. The same issue existed on the Trash page's Restore and Delete buttons.

## Changes

- **`cloud.component.html`** — Added `pTooltip` and `aria-label` to Download, Edit/Rename, and Delete buttons with context-aware labels (e.g. "Rename folder" vs "Edit file")
- **`trash/trash.component.html`** — Added `pTooltip` to Restore ("Restore to original location") and Delete ("Delete permanently") buttons
- **`trash/trash.component.ts`** — Imported `TooltipModule` to support the new `pTooltip` directives

## Audit Results

As part of this PR, a full codebase audit was performed:

- ✅ **Zero `alert()` calls** remain anywhere in the frontend — all HTTP errors use `UiToastService`
- ✅ **Zero emoji characters** in the Cloud/Trash pages — all action buttons use PrimeNG icons (`pi pi-trash`, `pi pi-pencil`, `pi pi-download`, `pi pi-refresh`, etc.)
- ✅ **Build passes** with no errors
- ✅ **Lint + Prettier** pass cleanly

## Testing

- [x] `npm run build` — success
- [x] `npx eslint` — no errors
- [x] `npx prettier --check` — formatted
