### PR TITLE
fix(dashboard): polish profile dashboard

### DIFF
--- a/backend/src/main/java/vaultWeb/repositories/GroupMemberRepository.java
+++ b/backend/src/main/java/vaultWeb/repositories/GroupMemberRepository.java
@@ -1,8 +1,11 @@
 package vaultWeb.repositories;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import vaultWeb.models.Group;
 import vaultWeb.models.GroupMember;
@@ -25,5 +28,18 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 
   long countByGroupAndRole(Group group, Role role);
 
-  long countByGroup(Group group);
+  @Query(
+      """
+      select gm.group.id as groupId, count(gm.id) as memberCount
+      from GroupMember gm
+      where gm.group.id in :groupIds
+      group by gm.group.id
+      """)
+  List<GroupMemberCount> countMembersByGroupIds(@Param("groupIds") Collection<Long> groupIds);
+
+  interface GroupMemberCount {
+    Long getGroupId();
+
+    long getMemberCount();
+  }
 }

--- a/backend/src/main/java/vaultWeb/services/DashboardService.java
+++ b/backend/src/main/java/vaultWeb/services/DashboardService.java
@@ -24,6 +24,7 @@ import vaultWeb.models.PrivateChat;
 import vaultWeb.models.User;
 import vaultWeb.repositories.ChatMessageRepository;
 import vaultWeb.repositories.GroupMemberRepository;
+import vaultWeb.repositories.GroupMemberRepository.GroupMemberCount;
 import vaultWeb.repositories.PollRepository;
 import vaultWeb.repositories.PrivateChatRepository;
 
@@ -66,6 +67,14 @@ public class DashboardService {
     List<Long> groupIds =
         memberships.stream().map(membership -> membership.getGroup().getId()).distinct().toList();
 
+    Map<Long, Long> memberCountsByGroup =
+        groupIds.isEmpty()
+            ? Map.of()
+            : groupMemberRepository.countMembersByGroupIds(groupIds).stream()
+                .collect(
+                    Collectors.toMap(
+                        GroupMemberCount::getGroupId, GroupMemberCount::getMemberCount));
+
     List<Poll> polls = groupIds.isEmpty() ? List.of() : pollRepository.findByGroupIdIn(groupIds);
     Map<Long, List<Poll>> pollsByGroup =
         polls.stream().collect(Collectors.groupingBy(poll -> poll.getGroup().getId()));
@@ -73,7 +82,8 @@ public class DashboardService {
     long messageCount = chatMessageRepository.countBySender(user);
     List<MessagePreview> recentMessages = buildRecentMessages(user);
 
-    List<GroupSummary> groupSummaries = buildGroupSummaries(memberships, pollsByGroup);
+    List<GroupSummary> groupSummaries =
+        buildGroupSummaries(memberships, pollsByGroup, memberCountsByGroup);
     List<PrivateChatSummary> privateChatSummaries = buildPrivateChatSummaries(privateChats, user);
     List<PollSummary> pollSummaries = buildPollSummaries(polls);
 
@@ -92,12 +102,14 @@ public class DashboardService {
   }
 
   private List<GroupSummary> buildGroupSummaries(
-      List<GroupMember> memberships, Map<Long, List<Poll>> pollsByGroup) {
+      List<GroupMember> memberships,
+      Map<Long, List<Poll>> pollsByGroup,
+      Map<Long, Long> memberCountsByGroup) {
     return memberships.stream()
         .map(
             membership -> {
               Group group = membership.getGroup();
-              long memberCount = groupMemberRepository.countByGroup(group);
+              long memberCount = memberCountsByGroup.getOrDefault(group.getId(), 0L);
               int pollCount = pollsByGroup.getOrDefault(group.getId(), List.of()).size();
               return new GroupSummary(
                   group.getId(),

--- a/backend/src/test/java/vaultWeb/services/DashboardServiceTest.java
+++ b/backend/src/test/java/vaultWeb/services/DashboardServiceTest.java
@@ -1,0 +1,98 @@
+package vaultWeb.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import vaultWeb.dtos.dashboard.UserDashboardDto;
+import vaultWeb.models.Group;
+import vaultWeb.models.GroupMember;
+import vaultWeb.models.User;
+import vaultWeb.models.enums.Role;
+import vaultWeb.repositories.ChatMessageRepository;
+import vaultWeb.repositories.GroupMemberRepository;
+import vaultWeb.repositories.GroupMemberRepository.GroupMemberCount;
+import vaultWeb.repositories.PollRepository;
+import vaultWeb.repositories.PrivateChatRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardServiceTest {
+
+  @Mock private GroupMemberRepository groupMemberRepository;
+  @Mock private PrivateChatRepository privateChatRepository;
+  @Mock private PollRepository pollRepository;
+  @Mock private ChatMessageRepository chatMessageRepository;
+
+  @InjectMocks private DashboardService dashboardService;
+
+  @Test
+  void shouldLoadMemberCountsForAllGroupsWithOneQuery() {
+    User user = new User();
+    user.setId(1L);
+    user.setUsername("alice");
+
+    Group firstGroup = createGroup(10L, "First");
+    Group secondGroup = createGroup(20L, "Second");
+    List<GroupMember> memberships =
+        List.of(
+            new GroupMember(firstGroup, user, Role.ADMIN),
+            new GroupMember(secondGroup, user, Role.USER));
+
+    GroupMemberCount firstCount = memberCount(10L, 4L);
+    GroupMemberCount secondCount = memberCount(20L, 7L);
+
+    when(groupMemberRepository.findAllByUser(user)).thenReturn(memberships);
+    when(groupMemberRepository.countMembersByGroupIds(List.of(10L, 20L)))
+        .thenReturn(List.of(firstCount, secondCount));
+    when(privateChatRepository.findByUser1OrUser2(user, user)).thenReturn(List.of());
+    when(pollRepository.findByGroupIdIn(List.of(10L, 20L))).thenReturn(List.of());
+    when(chatMessageRepository.findTop10BySenderOrderByTimestampDesc(user)).thenReturn(List.of());
+
+    UserDashboardDto dashboard = dashboardService.buildDashboard(user);
+
+    assertEquals(4, dashboard.groups().get(0).memberCount());
+    assertEquals(7, dashboard.groups().get(1).memberCount());
+    verify(groupMemberRepository).countMembersByGroupIds(List.of(10L, 20L));
+  }
+
+  @Test
+  void shouldUseZeroWhenAGroupHasNoReturnedMemberCount() {
+    User user = new User();
+    user.setId(1L);
+    user.setUsername("alice");
+    Group group = createGroup(10L, "First");
+
+    when(groupMemberRepository.findAllByUser(user))
+        .thenReturn(List.of(new GroupMember(group, user, Role.USER)));
+    when(groupMemberRepository.countMembersByGroupIds(List.of(10L))).thenReturn(List.of());
+    when(privateChatRepository.findByUser1OrUser2(user, user)).thenReturn(List.of());
+    when(pollRepository.findByGroupIdIn(List.of(10L))).thenReturn(List.of());
+    when(chatMessageRepository.findTop10BySenderOrderByTimestampDesc(user)).thenReturn(List.of());
+
+    UserDashboardDto dashboard = dashboardService.buildDashboard(user);
+
+    assertEquals(0, dashboard.groups().getFirst().memberCount());
+  }
+
+  private Group createGroup(Long id, String name) {
+    Group group = new Group();
+    group.setId(id);
+    group.setName(name);
+    group.setIsPublic(false);
+    return group;
+  }
+
+  private GroupMemberCount memberCount(Long groupId, long count) {
+    GroupMemberCount projection = mock(GroupMemberCount.class);
+    when(projection.getGroupId()).thenReturn(groupId);
+    when(projection.getMemberCount()).thenReturn(count);
+    return projection;
+  }
+}

--- a/backend/src/test/java/vaultWeb/services/DashboardServiceTest.java
+++ b/backend/src/test/java/vaultWeb/services/DashboardServiceTest.java
@@ -1,11 +1,16 @@
 package vaultWeb.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -49,7 +54,8 @@ class DashboardServiceTest {
     GroupMemberCount secondCount = memberCount(20L, 7L);
 
     when(groupMemberRepository.findAllByUser(user)).thenReturn(memberships);
-    when(groupMemberRepository.countMembersByGroupIds(List.of(10L, 20L)))
+    when(groupMemberRepository.countMembersByGroupIds(
+            argThat(groupIds -> Set.copyOf(groupIds).equals(Set.of(10L, 20L)))))
         .thenReturn(List.of(firstCount, secondCount));
     when(privateChatRepository.findByUser1OrUser2(user, user)).thenReturn(List.of());
     when(pollRepository.findByGroupIdIn(List.of(10L, 20L))).thenReturn(List.of());
@@ -57,9 +63,13 @@ class DashboardServiceTest {
 
     UserDashboardDto dashboard = dashboardService.buildDashboard(user);
 
-    assertEquals(4, dashboard.groups().get(0).memberCount());
-    assertEquals(7, dashboard.groups().get(1).memberCount());
-    verify(groupMemberRepository).countMembersByGroupIds(List.of(10L, 20L));
+    Map<Long, UserDashboardDto.GroupSummary> groupsById =
+        dashboard.groups().stream()
+            .collect(Collectors.toMap(UserDashboardDto.GroupSummary::id, Function.identity()));
+    assertEquals(4, groupsById.get(10L).memberCount());
+    assertEquals(7, groupsById.get(20L).memberCount());
+    verify(groupMemberRepository)
+        .countMembersByGroupIds(argThat(groupIds -> Set.copyOf(groupIds).equals(Set.of(10L, 20L))));
   }
 
   @Test

--- a/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -66,6 +66,9 @@
               *ngIf="profilePictureUrl; else dashboardInitial"
               [src]="profilePictureUrl"
               alt="Your profile picture"
+              width="88"
+              height="88"
+              loading="lazy"
               style="width: 100%; height: 100%; object-fit: cover"
             />
             <ng-template #dashboardInitial>
@@ -267,10 +270,7 @@
             <ul class="timeline" *ngIf="data.recentMessages.length">
               <li
                 class="timeline-entry"
-                *ngFor="
-                  let message of recentMessagesLimited;
-                  trackBy: trackById
-                "
+                *ngFor="let message of data.recentMessages; trackBy: trackById"
                 [class.timeline-entry-clickable]="canOpenRecentMessage(message)"
                 [attr.role]="canOpenRecentMessage(message) ? 'button' : null"
                 [attr.tabindex]="canOpenRecentMessage(message) ? 0 : -1"
@@ -292,9 +292,6 @@
               </li>
             </ul>
           </div>
-          <p class="timeline-overflow-note" *ngIf="hasMoreRecentMessages">
-            {{ hiddenRecentMessagesCount }} older message(s) hidden.
-          </p>
         </section>
       </div>
 

--- a/frontend/src/app/pages/dashboard/dashboard.component.scss
+++ b/frontend/src/app/pages/dashboard/dashboard.component.scss
@@ -300,12 +300,6 @@
   padding-right: 0.25rem;
 }
 
-.timeline-overflow-note {
-  margin: 0.6rem 0 0;
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-}
-
 .timeline::before {
   content: "";
   position: absolute;

--- a/frontend/src/app/pages/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.spec.ts
@@ -1,6 +1,6 @@
 import { fakeAsync, tick } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { UserDashboardDto } from '../../models/dtos/UserDashboardDto';
 import { AuthService } from '../../services/auth.service';
 import { DashboardService } from '../../services/dashboard.service';
@@ -78,5 +78,18 @@ describe('DashboardComponent', () => {
     tick(4000);
 
     expect(component.pictureSuccess).toBe('Profile picture removed.');
+  }));
+
+  it('ignores a profile-picture response received after destroy', fakeAsync(() => {
+    const deleteResult = new Subject<void>();
+    userService.deleteProfilePicture.and.returnValue(deleteResult);
+
+    component.removeProfilePicture();
+    component.ngOnDestroy();
+    deleteResult.next();
+    deleteResult.complete();
+    tick(4000);
+
+    expect(component.pictureSuccess).toBe('');
   }));
 });

--- a/frontend/src/app/pages/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,82 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { of } from 'rxjs';
+import { UserDashboardDto } from '../../models/dtos/UserDashboardDto';
+import { AuthService } from '../../services/auth.service';
+import { DashboardService } from '../../services/dashboard.service';
+import { UserService } from '../../services/user.service';
+import { DashboardComponent } from './dashboard.component';
+
+describe('DashboardComponent', () => {
+  const dashboard: UserDashboardDto = {
+    profile: {
+      id: 1,
+      username: 'alice',
+      groupCount: 0,
+      privateChatCount: 0,
+      messagesSent: 0,
+      profilePicture: '/uploads/alice.png',
+    },
+    groups: [],
+    privateChats: [],
+    polls: [],
+    recentMessages: [],
+  };
+
+  let dashboardService: jasmine.SpyObj<DashboardService>;
+  let userService: jasmine.SpyObj<UserService>;
+  let component: DashboardComponent;
+
+  beforeEach(() => {
+    dashboardService = jasmine.createSpyObj<DashboardService>(
+      'DashboardService',
+      ['getDashboard'],
+    );
+    userService = jasmine.createSpyObj<UserService>('UserService', [
+      'getProfilePicture',
+      'getProfilePictureUrl',
+      'uploadProfilePicture',
+      'deleteProfilePicture',
+    ]);
+    dashboardService.getDashboard.and.returnValue(of(dashboard));
+    userService.getProfilePictureUrl.and.returnValue(
+      'https://example.test/uploads/alice.png',
+    );
+
+    component = new DashboardComponent(
+      dashboardService,
+      new FormBuilder(),
+      jasmine.createSpyObj<AuthService>('AuthService', [
+        'getUsername',
+        'changePassword',
+      ]),
+      jasmine.createSpyObj('Router', ['navigate']),
+      userService,
+    );
+  });
+
+  it('uses the dashboard payload for the profile picture', () => {
+    component.ngOnInit();
+
+    expect(dashboardService.getDashboard).toHaveBeenCalledTimes(1);
+    expect(userService.getProfilePicture).not.toHaveBeenCalled();
+    expect(userService.getProfilePictureUrl).toHaveBeenCalledWith(
+      '/uploads/alice.png',
+    );
+    expect(component.profilePictureUrl).toBe(
+      'https://example.test/uploads/alice.png',
+    );
+  });
+
+  it('cancels the deferred success reset when destroyed', fakeAsync(() => {
+    userService.deleteProfilePicture.and.returnValue(of(void 0));
+
+    component.removeProfilePicture();
+    expect(component.pictureSuccess).toBe('Profile picture removed.');
+
+    component.ngOnDestroy();
+    tick(4000);
+
+    expect(component.pictureSuccess).toBe('Profile picture removed.');
+  }));
+});

--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -9,6 +9,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { Router } from '@angular/router';
+import { Subject, takeUntil } from 'rxjs';
 import { DashboardService } from '../../services/dashboard.service';
 import { UserDashboardDto } from '../../models/dtos/UserDashboardDto';
 import { AuthService } from '../../services/auth.service';
@@ -55,6 +56,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   pictureSuccess = '';
   pictureError = '';
   private pictureSuccessTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly destroy$ = new Subject<void>();
 
   // ── Password Visibility State ───────────────────────────────────────────
   showCurrentPassword = false;
@@ -76,6 +78,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
     this.clearPictureSuccessTimer();
   }
 
@@ -205,24 +209,27 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     this.isSavingPassword = true;
-    this.authService.changePassword(currentPassword, newPassword).subscribe({
-      next: () => {
-        this.isSavingPassword = false;
-        this.passwordSuccess = 'Password updated successfully.';
-        this.passwordForm.reset();
-        this.passwordForm.markAsPristine();
-        this.passwordForm.markAsUntouched();
-      },
-      error: (error) => {
-        this.isSavingPassword = false;
-        const serverMessage =
-          typeof error?.error === 'string'
-            ? error.error
-            : error?.error?.message;
-        this.passwordError =
-          serverMessage || 'Update failed. Please try again.';
-      },
-    });
+    this.authService
+      .changePassword(currentPassword, newPassword)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.isSavingPassword = false;
+          this.passwordSuccess = 'Password updated successfully.';
+          this.passwordForm.reset();
+          this.passwordForm.markAsPristine();
+          this.passwordForm.markAsUntouched();
+        },
+        error: (error) => {
+          this.isSavingPassword = false;
+          const serverMessage =
+            typeof error?.error === 'string'
+              ? error.error
+              : error?.error?.message;
+          this.passwordError =
+            serverMessage || 'Update failed. Please try again.';
+        },
+      });
   }
 
   isDeadlineActive(deadline: string | null): boolean {
@@ -248,21 +255,24 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.pictureError = '';
     this.isUploadingPicture = true;
 
-    this.userService.uploadProfilePicture(file).subscribe({
-      next: (res) => {
-        this.profilePictureUrl = this.userService.getProfilePictureUrl(
-          res.profilePicture,
-        );
-        this.isUploadingPicture = false;
-        this.pictureSuccess = 'Profile picture updated successfully!';
-        this.schedulePictureSuccessReset();
-      },
-      error: (err) => {
-        this.isUploadingPicture = false;
-        this.pictureError =
-          err?.error?.message || 'Upload failed. Please try again.';
-      },
-    });
+    this.userService
+      .uploadProfilePicture(file)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          this.profilePictureUrl = this.userService.getProfilePictureUrl(
+            res.profilePicture,
+          );
+          this.isUploadingPicture = false;
+          this.pictureSuccess = 'Profile picture updated successfully!';
+          this.schedulePictureSuccessReset();
+        },
+        error: (err) => {
+          this.isUploadingPicture = false;
+          this.pictureError =
+            err?.error?.message || 'Upload failed. Please try again.';
+        },
+      });
   }
 
   /**
@@ -273,18 +283,21 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.pictureError = '';
     this.isUploadingPicture = true;
 
-    this.userService.deleteProfilePicture().subscribe({
-      next: () => {
-        this.profilePictureUrl = null;
-        this.isUploadingPicture = false;
-        this.pictureSuccess = 'Profile picture removed.';
-        this.schedulePictureSuccessReset();
-      },
-      error: () => {
-        this.isUploadingPicture = false;
-        this.pictureError = 'Could not remove the picture. Please try again.';
-      },
-    });
+    this.userService
+      .deleteProfilePicture()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.profilePictureUrl = null;
+          this.isUploadingPicture = false;
+          this.pictureSuccess = 'Profile picture removed.';
+          this.schedulePictureSuccessReset();
+        },
+        error: () => {
+          this.isUploadingPicture = false;
+          this.pictureError = 'Could not remove the picture. Please try again.';
+        },
+      });
   }
 
   private loadDashboard(isRetry = false): void {
@@ -293,27 +306,30 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.error = null;
     }
 
-    this.dashboardService.getDashboard().subscribe({
-      next: (data) => {
-        this.dashboard = data;
-        this.profilePictureUrl = this.userService.getProfilePictureUrl(
-          data.profile.profilePicture,
-        );
-        this.privateChatParticipants = new Map(
-          data.privateChats.map((chat) => [chat.id, chat.participant]),
-        );
-        this.groupsById = new Map(
-          data.groups.map((group) => [group.id, group]),
-        );
-        this.isLoading = false;
-        this.error = null;
-        this.buildHighlights(data);
-      },
-      error: () => {
-        this.isLoading = false;
-        this.error = 'Failed to load the dashboard.';
-      },
-    });
+    this.dashboardService
+      .getDashboard()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (data) => {
+          this.dashboard = data;
+          this.profilePictureUrl = this.userService.getProfilePictureUrl(
+            data.profile.profilePicture,
+          );
+          this.privateChatParticipants = new Map(
+            data.privateChats.map((chat) => [chat.id, chat.participant]),
+          );
+          this.groupsById = new Map(
+            data.groups.map((group) => [group.id, group]),
+          );
+          this.isLoading = false;
+          this.error = null;
+          this.buildHighlights(data);
+        },
+        error: () => {
+          this.isLoading = false;
+          this.error = 'Failed to load the dashboard.';
+        },
+      });
   }
 
   private schedulePictureSuccessReset(): void {

--- a/frontend/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
@@ -19,7 +19,6 @@ import {
   PrivateChatSummary,
 } from '../../models/dtos/UserDashboardDto';
 import { PrivateChatDialogComponent } from '../private-chat-dialog/private-chat-dialog.component';
-import { UiToastService } from '../../core/services/ui-toast.service';
 
 interface StatHighlight {
   label: string;
@@ -35,12 +34,11 @@ interface StatHighlight {
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
 })
-export class DashboardComponent implements OnInit {
+export class DashboardComponent implements OnInit, OnDestroy {
   dashboard?: UserDashboardDto;
   isLoading = true;
   error: string | null = null;
   statHighlights: StatHighlight[] = [];
-  readonly maxRecentMessages = 12;
   passwordForm: FormGroup;
   isSavingPassword = false;
   passwordSuccess = '';
@@ -56,6 +54,7 @@ export class DashboardComponent implements OnInit {
   isUploadingPicture = false;
   pictureSuccess = '';
   pictureError = '';
+  private pictureSuccessTimer: ReturnType<typeof setTimeout> | null = null;
 
   // ── Password Visibility State ───────────────────────────────────────────
   showCurrentPassword = false;
@@ -67,7 +66,6 @@ export class DashboardComponent implements OnInit {
     private fb: FormBuilder,
     private authService: AuthService,
     private router: Router,
-    private toast: UiToastService,
     private userService: UserService,
   ) {
     this.passwordForm = this.createPasswordForm();
@@ -75,7 +73,10 @@ export class DashboardComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadDashboard();
-    this.loadProfilePicture();
+  }
+
+  ngOnDestroy(): void {
+    this.clearPictureSuccessTimer();
   }
 
   retry(): void {
@@ -181,25 +182,8 @@ export class DashboardComponent implements OnInit {
     return item?.id ?? 0;
   }
 
-  get recentMessagesLimited(): MessagePreview[] {
-    return (
-      this.dashboard?.recentMessages.slice(0, this.maxRecentMessages) ?? []
-    );
-  }
-
   get currentUsername(): string | null {
     return this.authService.getUsername();
-  }
-
-  get hasMoreRecentMessages(): boolean {
-    return (
-      (this.dashboard?.recentMessages.length ?? 0) > this.maxRecentMessages
-    );
-  }
-
-  get hiddenRecentMessagesCount(): number {
-    const total = this.dashboard?.recentMessages.length ?? 0;
-    return Math.max(total - this.maxRecentMessages, 0);
   }
 
   get pf(): { [key: string]: AbstractControl } {
@@ -251,22 +235,6 @@ export class DashboardComponent implements OnInit {
   // ── Profile Picture Methods ───────────────────────────────────────────────
 
   /**
-   * Loads the current user's profile picture from the backend.
-   */
-  private loadProfilePicture(): void {
-    this.userService.getProfilePicture().subscribe({
-      next: (res) => {
-        this.profilePictureUrl = this.userService.getProfilePictureUrl(
-          res.profilePicture,
-        );
-      },
-      error: () => {
-        this.profilePictureUrl = null;
-      },
-    });
-  }
-
-  /**
    * Called when the user selects a file to upload.
    */
   onProfilePictureSelected(event: Event): void {
@@ -287,7 +255,7 @@ export class DashboardComponent implements OnInit {
         );
         this.isUploadingPicture = false;
         this.pictureSuccess = 'Profile picture updated successfully!';
-        setTimeout(() => (this.pictureSuccess = ''), 4000);
+        this.schedulePictureSuccessReset();
       },
       error: (err) => {
         this.isUploadingPicture = false;
@@ -310,7 +278,7 @@ export class DashboardComponent implements OnInit {
         this.profilePictureUrl = null;
         this.isUploadingPicture = false;
         this.pictureSuccess = 'Profile picture removed.';
-        setTimeout(() => (this.pictureSuccess = ''), 4000);
+        this.schedulePictureSuccessReset();
       },
       error: () => {
         this.isUploadingPicture = false;
@@ -328,6 +296,9 @@ export class DashboardComponent implements OnInit {
     this.dashboardService.getDashboard().subscribe({
       next: (data) => {
         this.dashboard = data;
+        this.profilePictureUrl = this.userService.getProfilePictureUrl(
+          data.profile.profilePicture,
+        );
         this.privateChatParticipants = new Map(
           data.privateChats.map((chat) => [chat.id, chat.participant]),
         );
@@ -343,6 +314,21 @@ export class DashboardComponent implements OnInit {
         this.error = 'Failed to load the dashboard.';
       },
     });
+  }
+
+  private schedulePictureSuccessReset(): void {
+    this.clearPictureSuccessTimer();
+    this.pictureSuccessTimer = setTimeout(() => {
+      this.pictureSuccess = '';
+      this.pictureSuccessTimer = null;
+    }, 4000);
+  }
+
+  private clearPictureSuccessTimer(): void {
+    if (this.pictureSuccessTimer) {
+      clearTimeout(this.pictureSuccessTimer);
+      this.pictureSuccessTimer = null;
+    }
   }
 
   private buildHighlights(data: UserDashboardDto): void {


### PR DESCRIPTION
## Summary

- Replaced the dashboard’s per-group member-count queries with one grouped query.
- Removed the redundant profile-picture request and reused the dashboard payload.
- Added lifecycle-safe cleanup for deferred profile-picture success messages.
- Added explicit profile-image dimensions and lazy loading.
- Removed unreachable client-side recent-message limiting because the backend already limits results.
- Added backend and frontend regression tests.

## Linked issue

Closes #273

## How to test

1. Open the profile dashboard and verify the profile picture loads correctly.
2. Upload and remove a profile picture, then navigate away before the success message resets.
3. Verify groups, member counts, private chats, polls, recent messages, statistics, and password changes still work.
4. Run:

```
cd backend
./mvnw spotless:check test

cd ../frontend
npm ci
npx eslint src --ext .ts,.html
npx ng build --configuration=development
npx ng test --watch=false --browsers=ChromeHeadless \
  --include=src/app/pages/dashboard/dashboard.component.spec.ts
```

## Notes / Risk

- No database migrations, feature flags, or configuration changes are required.
- The grouped member-count query changes query shape but preserves the dashboard response contract.
- The existing Angular `*ngIf`/`*ngFor` syntax was retained for consistency with the rest of the application.
- The backend already limits recent messages to ten, so no additional server-side limit was necessary.