### PR TITLE
feat(cloud): add SHA-256 file integrity checksum verification UI (#282)

### DIFF
--- a/frontend/src/app/models/dtos/FileChecksumDto.ts
+++ b/frontend/src/app/models/dtos/FileChecksumDto.ts
@@ -1,0 +1,5 @@
+export interface FileChecksumDto {
+  filePath: string;
+  checksum: string;
+  algorithm: string;
+}

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -226,6 +226,15 @@
                 ariaLabel="Download file"
               ></p-button>
               <p-button
+                *ngIf="entry.kind === 'file'"
+                icon="pi pi-shield"
+                styleClass="p-button-rounded p-button-text p-button-sm cloud-icon-btn"
+                (click)="openChecksumDialog(entry)"
+                pTooltip="Verify file integrity (SHA-256)"
+                tooltipPosition="top"
+                ariaLabel="Verify file integrity (SHA-256)"
+              ></p-button>
+              <p-button
                 icon="pi pi-pencil"
                 styleClass="p-button-rounded p-button-text p-button-sm cloud-icon-btn"
                 (click)="
@@ -647,6 +656,137 @@
         styleClass="p-button-sm text-xxs sm:text-xs"
         [disabled]="scanning"
         (click)="scanCurrentFolder()"
+      ></p-button>
+    </ng-template>
+  </p-dialog>
+
+  <!-- Checksum / File Integrity Dialog -->
+  <p-dialog
+    [(visible)]="showChecksumDialog"
+    header="File Integrity Checksum (SHA-256)"
+    [modal]="true"
+    [style]="{ width: '90vw', maxWidth: '580px' }"
+    [draggable]="false"
+    [resizable]="false"
+    styleClass="cloud-dialog shadow-2xl rounded-2xl overflow-hidden text-xs sm:text-sm"
+  >
+    <div class="cloud-checksum-dialog p-2 sm:p-4 space-y-4">
+      <!-- File Metadata Header -->
+      <div
+        class="flex items-start gap-3 p-3 bg-slate-800/60 dark:bg-slate-900/60 rounded-xl border border-slate-700/50"
+      >
+        <i class="pi pi-file-check text-indigo-400 text-2xl mt-0.5"></i>
+        <div class="min-w-0 flex-1">
+          <p class="font-semibold text-slate-200 truncate">
+            {{ selectedFileForChecksum?.name || "File" }}
+          </p>
+          <p class="text-xs text-slate-400 truncate">
+            {{ selectedFileForChecksum?.path }}
+          </p>
+        </div>
+      </div>
+
+      <!-- Loading State -->
+      <div *ngIf="checksumLoading" class="py-8 text-center space-y-3">
+        <i class="pi pi-spin pi-spinner text-3xl text-indigo-400"></i>
+        <p class="text-xs sm:text-sm text-slate-300 font-medium">
+          Computing SHA-256 checksum...
+        </p>
+        <p class="text-xxs sm:text-xs text-slate-400">
+          This may take a moment for large files.
+        </p>
+      </div>
+
+      <!-- Error State -->
+      <div
+        *ngIf="!checksumLoading && checksumError"
+        class="p-4 bg-red-950/40 border border-red-800/50 rounded-xl text-red-300 flex items-start gap-3"
+      >
+        <i class="pi pi-exclamation-triangle text-red-400 text-lg mt-0.5"></i>
+        <div>
+          <p class="font-semibold text-xs sm:text-sm">
+            Failed to calculate checksum
+          </p>
+          <p class="text-xs text-red-400 mt-1">{{ checksumError }}</p>
+        </div>
+      </div>
+
+      <!-- Computed Checksum Section -->
+      <div *ngIf="!checksumLoading && checksumResult" class="space-y-3">
+        <div>
+          <label
+            class="block text-xs font-semibold text-slate-300 mb-1.5 uppercase tracking-wider"
+          >
+            Computed Hash ({{ checksumResult.algorithm || "SHA-256" }})
+          </label>
+          <div class="flex items-center gap-2">
+            <div
+              class="flex-1 p-3 bg-slate-950/80 border border-slate-700/70 rounded-xl font-mono text-xs sm:text-sm text-emerald-400 break-all select-all font-medium tracking-tight leading-relaxed shadow-inner"
+            >
+              {{ checksumResult.checksum }}
+            </div>
+            <p-button
+              icon="pi pi-copy"
+              [label]="copiedHashState ? 'Copied' : 'Copy'"
+              [styleClass]="
+                copiedHashState
+                  ? 'p-button-success p-button-sm text-xs'
+                  : 'p-button-outlined p-button-sm text-xs'
+              "
+              (click)="copyChecksumToClipboard()"
+              pTooltip="Copy SHA-256 to clipboard"
+              tooltipPosition="top"
+            ></p-button>
+          </div>
+        </div>
+
+        <!-- Optional Expected Hash Verification Section -->
+        <div class="pt-2 border-t border-slate-700/40 space-y-2">
+          <label
+            class="block text-xs font-semibold text-slate-300 uppercase tracking-wider"
+          >
+            Verify Against Expected Hash
+          </label>
+          <input
+            type="text"
+            pInputText
+            [(ngModel)]="expectedHash"
+            placeholder="Paste expected SHA-256 hash here..."
+            class="w-full p-2.5 text-xs sm:text-sm font-mono bg-slate-900/80 border border-slate-700 rounded-xl focus:border-indigo-500 text-slate-200"
+          />
+
+          <!-- Comparison Status Badges -->
+          <div *ngIf="expectedHash.trim()" class="mt-2">
+            <div
+              *ngIf="hashMatchStatus === 'match'"
+              class="p-3 bg-emerald-950/50 border border-emerald-500/40 text-emerald-300 rounded-xl flex items-center gap-2.5 text-xs sm:text-sm font-medium"
+            >
+              <i class="pi pi-check-circle text-emerald-400 text-base"></i>
+              <span
+                ><strong>Hashes Match!</strong> The file is intact and
+                authentic.</span
+              >
+            </div>
+            <div
+              *ngIf="hashMatchStatus === 'mismatch'"
+              class="p-3 bg-red-950/50 border border-red-500/40 text-red-300 rounded-xl flex items-center gap-2.5 text-xs sm:text-sm font-medium"
+            >
+              <i class="pi pi-times-circle text-red-400 text-base"></i>
+              <span
+                ><strong>Hash Mismatch!</strong> The file may be modified or
+                corrupted.</span
+              >
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <ng-template pTemplate="footer">
+      <p-button
+        label="Close"
+        styleClass="p-button-text p-button-sm text-xs"
+        (click)="showChecksumDialog = false"
       ></p-button>
     </ng-template>
   </p-dialog>

--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -681,6 +681,7 @@
   <!-- Checksum / File Integrity Dialog -->
   <p-dialog
     [(visible)]="showChecksumDialog"
+    (onHide)="onChecksumDialogHide()"
     header="File Integrity Checksum (SHA-256)"
     [modal]="true"
     [style]="{ width: '90vw', maxWidth: '580px' }"
@@ -804,7 +805,7 @@
       <p-button
         label="Close"
         styleClass="p-button-text p-button-sm text-xs"
-        (click)="showChecksumDialog = false"
+        (click)="onChecksumDialogHide()"
       ></p-button>
     </ng-template>
   </p-dialog>

--- a/frontend/src/app/pages/cloud/cloud.component.spec.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.spec.ts
@@ -241,351 +241,350 @@ describe('CloudComponent virus scan', () => {
 
     expect(cloudMock.getScanJob).not.toHaveBeenCalled();
   });
-  describe('CloudComponent File Checksum', () => {
-    let component: CloudComponent;
-    let cloudMock: jasmine.SpyObj<CloudService>;
-    let toastMock: { success: jasmine.Spy; error: jasmine.Spy };
+});
 
-    beforeEach(() => {
-      cloudMock = jasmine.createSpyObj<CloudService>('CloudService', [
-        'getFileChecksum',
-      ]);
-      toastMock = {
-        success: jasmine.createSpy('success'),
-        error: jasmine.createSpy('error'),
-      };
-      component = new CloudComponent(
-        cloudMock,
-        {} as never,
-        toastMock as never,
-        {} as never,
-        {} as never,
-      );
-      component.rootPath = '/root';
-    });
+describe('CloudComponent File Checksum', () => {
+  let component: CloudComponent;
+  let cloudMock: jasmine.SpyObj<CloudService>;
+  let toastMock: { success: jasmine.Spy; error: jasmine.Spy };
 
-    it('should open dialog and load file checksum successfully', () => {
-      const mockChecksum = {
-        filePath: 'test.pdf',
-        checksum:
-          'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-        algorithm: 'SHA-256',
-      };
-      cloudMock.getFileChecksum.and.returnValue(of(mockChecksum));
-
-      component.openChecksumDialog({
-        name: 'test.pdf',
-        path: '/root/test.pdf',
-      });
-
-      expect(component.showChecksumDialog).toBeTrue();
-      expect(component.selectedFileForChecksum?.name).toBe('test.pdf');
-      expect(component.checksumLoading).toBeFalse();
-      expect(component.checksumResult?.checksum).toBe(
-        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-      );
-    });
-
-    it('should handle checksum error and invoke toast notification', () => {
-      cloudMock.getFileChecksum.and.returnValue(
-        throwError(() => new Error('Checksum endpoint failure')),
-      );
-
-      component.openChecksumDialog({
-        name: 'corrupted.zip',
-        path: '/root/corrupted.zip',
-      });
-
-      expect(component.checksumLoading).toBeFalse();
-      expect(component.checksumError).toContain('Checksum endpoint failure');
-      expect(toastMock.error).toHaveBeenCalled();
-    });
-
-    it('should evaluate expected hash comparison correctly', () => {
-      component.checksumResult = {
-        filePath: 'doc.txt',
-        checksum: 'A1B2C3D4E5',
-        algorithm: 'SHA-256',
-      };
-
-      component.expectedHash = '';
-      expect(component.hashMatchStatus).toBe('empty');
-
-      component.expectedHash = 'a1b2c3d4e5';
-      expect(component.hashMatchStatus).toBe('match');
-
-      component.expectedHash = 'wronghash123';
-      expect(component.hashMatchStatus).toBe('mismatch');
-    });
-
-    it('should copy checksum to clipboard and set toast notification', () => {
-      component.checksumResult = {
-        filePath: 'doc.txt',
-        checksum: '1234567890abcdef',
-        algorithm: 'SHA-256',
-      };
-
-      component.copyChecksumToClipboard();
-
-      expect(component.copiedHashState).toBeTrue();
-      expect(toastMock.success).toHaveBeenCalledWith(
-        'Checksum Copied',
-        jasmine.any(String),
-      );
-    });
+  beforeEach(() => {
+    cloudMock = jasmine.createSpyObj<CloudService>('CloudService', [
+      'getFileChecksum',
+    ]);
+    toastMock = {
+      success: jasmine.createSpy('success'),
+      error: jasmine.createSpy('error'),
+    };
+    component = new CloudComponent(
+      cloudMock,
+      {} as never,
+      toastMock as never,
+      {} as never,
+      {} as never,
+    );
+    component.rootPath = '/root';
   });
 
-  describe('CloudComponent Secure Send Flow', () => {
-    let component: CloudComponent;
-    let fixture: ComponentFixture<CloudComponent>;
-    let cloudServiceSpy: jasmine.SpyObj<CloudService>;
-    let toastSpy: jasmine.SpyObj<UiToastService>;
+  it('should open dialog and load file checksum successfully', () => {
+    const mockChecksum = {
+      filePath: 'test.pdf',
+      checksum:
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      algorithm: 'SHA-256',
+    };
+    cloudMock.getFileChecksum.and.returnValue(of(mockChecksum));
 
-    beforeEach(async () => {
-      cloudServiceSpy = jasmine.createSpyObj('CloudService', [
-        'getRootFolder',
-        'getFolderByPath',
-        'getFolderContent',
-        'createSecureSendLink',
-        'listSecureSendLinks',
-        'revokeSecureSendLink',
-      ]);
-
-      cloudServiceSpy.getRootFolder.and.returnValue(
-        of({ id: 'root', name: 'Root', path: '/' } as any),
-      );
-      cloudServiceSpy.getFolderContent.and.returnValue(
-        of({ content: [], totalElements: 0, totalPages: 0, page: 0 } as any),
-      );
-
-      toastSpy = jasmine.createSpyObj('UiToastService', [
-        'success',
-        'error',
-        'info',
-        'warn',
-      ]);
-
-      await TestBed.configureTestingModule({
-        imports: [
-          CloudComponent,
-          HttpClientTestingModule,
-          RouterTestingModule,
-          NoopAnimationsModule,
-        ],
-        providers: [
-          { provide: CloudService, useValue: cloudServiceSpy },
-          { provide: UiToastService, useValue: toastSpy },
-        ],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(CloudComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
+    component.openChecksumDialog({
+      name: 'test.pdf',
+      path: '/root/test.pdf',
     });
 
-    it('should open create share link dialog for a file', () => {
-      component.openCreateShareDialog('/file.txt', 'file.txt');
-      expect(component.selectedFileForShare).toEqual({
-        path: '/file.txt',
-        name: 'file.txt',
-      });
-      expect(component.showCreateShareDialog).toBeTrue();
-      expect(component.shareExpiryMinutes).toBe(1440);
+    expect(component.showChecksumDialog).toBeTrue();
+    expect(component.selectedFileForChecksum?.name).toBe('test.pdf');
+    expect(component.checksumLoading).toBeFalse();
+    expect(component.checksumResult?.checksum).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    );
+  });
+
+  it('should handle checksum error and invoke toast notification', () => {
+    cloudMock.getFileChecksum.and.returnValue(
+      throwError(() => new Error('Checksum endpoint failure')),
+    );
+
+    component.openChecksumDialog({
+      name: 'corrupted.zip',
+      path: '/root/corrupted.zip',
     });
 
-    it('should create a secure send link and open generated URL dialog on success', () => {
-      component.selectedFileForShare = { path: '/doc.pdf', name: 'doc.pdf' };
-      component.shareExpiryMinutes = 60;
-      component.sharePassword = 'pass';
+    expect(component.checksumLoading).toBeFalse();
+    expect(component.checksumError).toContain('Checksum endpoint failure');
+    expect(toastMock.error).toHaveBeenCalled();
+  });
 
-      const mockLink: SecureSendLinkDto = {
-        id: 's1',
-        filePath: '/doc.pdf',
-        fileName: 'doc.pdf',
-        shareUrl: 'http://localhost/share/s1',
-        expiresAt: '2026-07-21T00:00:00Z',
-        createdAt: '2026-07-20T00:00:00Z',
-      };
+  it('should evaluate expected hash comparison correctly', () => {
+    component.checksumResult = {
+      filePath: 'doc.txt',
+      checksum: 'A1B2C3D4E5',
+      algorithm: 'SHA-256',
+    };
 
-      cloudServiceSpy.createSecureSendLink.and.returnValue(of(mockLink));
+    component.expectedHash = '';
+    expect(component.hashMatchStatus).toBe('empty');
 
-      component.submitCreateShareLink();
+    component.expectedHash = 'a1b2c3d4e5';
+    expect(component.hashMatchStatus).toBe('match');
 
-      expect(cloudServiceSpy.createSecureSendLink).toHaveBeenCalledWith(
-        '/doc.pdf',
-        60,
-        'pass',
-      );
-      expect(component.createdShareUrl).toBe('http://localhost/share/s1');
-      expect(component.showCreateShareDialog).toBeFalse();
-      expect(component.showGeneratedLinkDialog).toBeTrue();
-      expect(toastSpy.success).toHaveBeenCalledWith(
-        'Share link created',
-        'Link for "doc.pdf" created successfully.',
-      );
+    component.expectedHash = 'wronghash123';
+    expect(component.hashMatchStatus).toBe('mismatch');
+  });
+
+  it('should copy checksum to clipboard and set toast notification', () => {
+    component.checksumResult = {
+      filePath: 'doc.txt',
+      checksum: '1234567890abcdef',
+      algorithm: 'SHA-256',
+    };
+
+    component.copyChecksumToClipboard();
+
+    expect(component.copiedHashState).toBeTrue();
+    expect(toastMock.success).toHaveBeenCalledWith(
+      'Checksum Copied',
+      jasmine.any(String),
+    );
+  });
+});
+
+describe('CloudComponent Secure Send Flow', () => {
+  let component: CloudComponent;
+  let fixture: ComponentFixture<CloudComponent>;
+  let cloudServiceSpy: jasmine.SpyObj<CloudService>;
+  let toastSpy: jasmine.SpyObj<UiToastService>;
+
+  beforeEach(async () => {
+    cloudServiceSpy = jasmine.createSpyObj('CloudService', [
+      'getRootFolder',
+      'getFolderByPath',
+      'getFolderContent',
+      'createSecureSendLink',
+      'listSecureSendLinks',
+      'revokeSecureSendLink',
+    ]);
+
+    cloudServiceSpy.getRootFolder.and.returnValue(
+      of({ id: 'root', name: 'Root', path: '/' } as any),
+    );
+    cloudServiceSpy.getFolderContent.and.returnValue(
+      of({ content: [], totalElements: 0, totalPages: 0, page: 0 } as any),
+    );
+
+    toastSpy = jasmine.createSpyObj('UiToastService', [
+      'success',
+      'error',
+      'info',
+      'warn',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        CloudComponent,
+        HttpClientTestingModule,
+        RouterTestingModule,
+        NoopAnimationsModule,
+      ],
+      providers: [
+        { provide: CloudService, useValue: cloudServiceSpy },
+        { provide: UiToastService, useValue: toastSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CloudComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should open create share link dialog for a file', () => {
+    component.openCreateShareDialog('/file.txt', 'file.txt');
+    expect(component.selectedFileForShare).toEqual({
+      path: '/file.txt',
+      name: 'file.txt',
     });
+    expect(component.showCreateShareDialog).toBeTrue();
+    expect(component.shareExpiryMinutes).toBe(1440);
+  });
 
-    it('should handle rate limit error (HTTP 429) when creating share link', () => {
-      component.selectedFileForShare = { path: '/doc.pdf', name: 'doc.pdf' };
-      cloudServiceSpy.createSecureSendLink.and.returnValue(
-        throwError(() => ({ status: 429, message: 'Too Many Requests' })),
-      );
+  it('should create a secure send link and open generated URL dialog on success', () => {
+    component.selectedFileForShare = { path: '/doc.pdf', name: 'doc.pdf' };
+    component.shareExpiryMinutes = 60;
+    component.sharePassword = 'pass';
 
-      component.submitCreateShareLink();
+    const mockLink: SecureSendLinkDto = {
+      id: 's1',
+      filePath: '/doc.pdf',
+      fileName: 'doc.pdf',
+      shareUrl: 'http://localhost/share/s1',
+      expiresAt: '2026-07-21T00:00:00Z',
+      createdAt: '2026-07-20T00:00:00Z',
+    };
 
-      expect(toastSpy.error).toHaveBeenCalledWith(
-        'Rate limit reached',
-        'Too many share links created. Please wait before trying again.',
-      );
-    });
+    cloudServiceSpy.createSecureSendLink.and.returnValue(of(mockLink));
 
-    it('should load active share links in dialog', () => {
-      const mockLinks: SecureSendLinkDto[] = [
-        {
-          id: 'link1',
-          filePath: '/a.txt',
-          fileName: 'a.txt',
-          expiresAt: '2026-07-25T00:00:00Z',
-          createdAt: '2026-07-20T00:00:00Z',
-        },
-      ];
+    component.submitCreateShareLink();
 
-      cloudServiceSpy.listSecureSendLinks.and.returnValue(of(mockLinks));
+    expect(cloudServiceSpy.createSecureSendLink).toHaveBeenCalledWith(
+      '/doc.pdf',
+      60,
+      'pass',
+    );
+    expect(component.createdShareUrl).toBe('http://localhost/share/s1');
+    expect(component.showCreateShareDialog).toBeFalse();
+    expect(component.showGeneratedLinkDialog).toBeTrue();
+    expect(toastSpy.success).toHaveBeenCalledWith(
+      'Share link created',
+      'Link for "doc.pdf" created successfully.',
+    );
+  });
 
-      component.openSharedLinksDialog();
+  it('should handle rate limit error (HTTP 429) when creating share link', () => {
+    component.selectedFileForShare = { path: '/doc.pdf', name: 'doc.pdf' };
+    cloudServiceSpy.createSecureSendLink.and.returnValue(
+      throwError(() => ({ status: 429, message: 'Too Many Requests' })),
+    );
 
-      expect(component.showSharedLinksDialog).toBeTrue();
-      expect(component.sharedLinks).toEqual(mockLinks);
-    });
+    component.submitCreateShareLink();
 
-    it('should revoke a share link and update UI state', () => {
-      const link: SecureSendLinkDto = {
+    expect(toastSpy.error).toHaveBeenCalledWith(
+      'Rate limit reached',
+      'Too many share links created. Please wait before trying again.',
+    );
+  });
+
+  it('should load active share links in dialog', () => {
+    const mockLinks: SecureSendLinkDto[] = [
+      {
         id: 'link1',
         filePath: '/a.txt',
         fileName: 'a.txt',
         expiresAt: '2026-07-25T00:00:00Z',
         createdAt: '2026-07-20T00:00:00Z',
-        isRevoked: false,
-      };
+      },
+    ];
 
-      cloudServiceSpy.revokeSecureSendLink.and.returnValue(of(void 0));
+    cloudServiceSpy.listSecureSendLinks.and.returnValue(of(mockLinks));
 
-      component.revokeShareLink(link);
+    component.openSharedLinksDialog();
 
-      expect(cloudServiceSpy.revokeSecureSendLink).toHaveBeenCalledWith(
-        'link1',
-      );
-      expect(link.isRevoked).toBeTrue();
-      expect(toastSpy.success).toHaveBeenCalledWith(
-        'Link revoked',
-        'Share link for "a.txt" was revoked.',
-      );
-    });
+    expect(component.showSharedLinksDialog).toBeTrue();
+    expect(component.sharedLinks).toEqual(mockLinks);
   });
 
-  /**
-   * The unsaved-changes guard on the Cloud file editor: every exit path (Cancel,
-   * the dialog dismiss, and a full-page leave) must confirm before discarding
-   * edits, and a clean editor must close without a prompt.
-   */
-  describe('CloudComponent unsaved-edit guard', () => {
-    let component: CloudComponent;
-    let confirmMock: jasmine.SpyObj<{ confirm: (config: unknown) => void }>;
+  it('should revoke a share link and update UI state', () => {
+    const link: SecureSendLinkDto = {
+      id: 'link1',
+      filePath: '/a.txt',
+      fileName: 'a.txt',
+      expiresAt: '2026-07-25T00:00:00Z',
+      createdAt: '2026-07-20T00:00:00Z',
+      isRevoked: false,
+    };
 
-    beforeEach(() => {
-      confirmMock = jasmine.createSpyObj('ConfirmationService', ['confirm']);
-      component = new CloudComponent(
-        {} as never,
-        confirmMock as never,
-        {} as never,
-        {} as never,
-        {} as never,
-      );
-    });
+    cloudServiceSpy.revokeSecureSendLink.and.returnValue(of(void 0));
 
-    // Open the editor on a file whose loaded state is not yet dirty.
-    function openEditor(content: string, fileName = 'note.txt'): void {
-      component.showFileEditor = true;
-      component.newFileName = fileName;
-      component.originalFileName = fileName;
-      component.fileContent = content;
-      component.originalFileContent = content;
-    }
+    component.revokeShareLink(link);
 
-    function acceptLastConfirm(): void {
-      const config = confirmMock.confirm.calls.mostRecent().args[0] as {
-        accept: () => void;
-      };
-      config.accept();
-    }
+    expect(cloudServiceSpy.revokeSecureSendLink).toHaveBeenCalledWith('link1');
+    expect(link.isRevoked).toBeTrue();
+    expect(toastSpy.success).toHaveBeenCalledWith(
+      'Link revoked',
+      'Share link for "a.txt" was revoked.',
+    );
+  });
+});
 
-    it('closes without asking when the editor has no unsaved edits', () => {
-      openEditor('hello');
-      component.requestCloseFileEditor();
-      expect(confirmMock.confirm).not.toHaveBeenCalled();
-      expect(component.showFileEditor).toBeFalse();
-    });
+/**
+ * The unsaved-changes guard on the Cloud file editor: every exit path (Cancel,
+ * the dialog dismiss, and a full-page leave) must confirm before discarding
+ * edits, and a clean editor must close without a prompt.
+ */
+describe('CloudComponent unsaved-edit guard', () => {
+  let component: CloudComponent;
+  let confirmMock: jasmine.SpyObj<{ confirm: (config: unknown) => void }>;
 
-    it('asks before discarding, and only closes once Discard is confirmed', () => {
-      openEditor('hello');
-      component.fileContent = 'hello world'; // dirty
+  beforeEach(() => {
+    confirmMock = jasmine.createSpyObj('ConfirmationService', ['confirm']);
+    component = new CloudComponent(
+      {} as never,
+      confirmMock as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+  });
 
-      component.requestCloseFileEditor();
-      expect(confirmMock.confirm).toHaveBeenCalledTimes(1);
-      expect(component.showFileEditor).toBeTrue(); // stays open until confirmed
+  // Open the editor on a file whose loaded state is not yet dirty.
+  function openEditor(content: string, fileName = 'note.txt'): void {
+    component.showFileEditor = true;
+    component.newFileName = fileName;
+    component.originalFileName = fileName;
+    component.fileContent = content;
+    component.originalFileContent = content;
+  }
 
-      acceptLastConfirm();
-      expect(component.showFileEditor).toBeFalse();
-      expect(component.fileContent).toBe(''); // editor state fully reset
-    });
+  function acceptLastConfirm(): void {
+    const config = confirmMock.confirm.calls.mostRecent().args[0] as {
+      accept: () => void;
+    };
+    config.accept();
+  }
 
-    it('asks before discarding when only the file name changed', () => {
-      openEditor('hello', 'old.txt');
-      component.newFileName = 'new.txt';
+  it('closes without asking when the editor has no unsaved edits', () => {
+    openEditor('hello');
+    component.requestCloseFileEditor();
+    expect(confirmMock.confirm).not.toHaveBeenCalled();
+    expect(component.showFileEditor).toBeFalse();
+  });
 
-      component.requestCloseFileEditor();
+  it('asks before discarding, and only closes once Discard is confirmed', () => {
+    openEditor('hello');
+    component.fileContent = 'hello world'; // dirty
 
-      expect(confirmMock.confirm).toHaveBeenCalledTimes(1);
-      expect(component.showFileEditor).toBeTrue();
-    });
+    component.requestCloseFileEditor();
+    expect(confirmMock.confirm).toHaveBeenCalledTimes(1);
+    expect(component.showFileEditor).toBeTrue(); // stays open until confirmed
 
-    it('reverses a dialog dismiss and confirms when there are unsaved edits', () => {
-      openEditor('hello');
-      component.fileContent = 'changed';
-      component.showFileEditor = false; // the dismiss already flipped visible off
+    acceptLastConfirm();
+    expect(component.showFileEditor).toBeFalse();
+    expect(component.fileContent).toBe(''); // editor state fully reset
+  });
 
-      component.onFileEditorHide();
+  it('asks before discarding when only the file name changed', () => {
+    openEditor('hello', 'old.txt');
+    component.newFileName = 'new.txt';
 
-      expect(component.showFileEditor).toBeTrue(); // reopened
-      expect(confirmMock.confirm).toHaveBeenCalledTimes(1);
-    });
+    component.requestCloseFileEditor();
 
-    it('lets a clean dialog dismiss close with no prompt', () => {
-      openEditor('hello');
-      component.showFileEditor = false;
+    expect(confirmMock.confirm).toHaveBeenCalledTimes(1);
+    expect(component.showFileEditor).toBeTrue();
+  });
 
-      component.onFileEditorHide();
+  it('reverses a dialog dismiss and confirms when there are unsaved edits', () => {
+    openEditor('hello');
+    component.fileContent = 'changed';
+    component.showFileEditor = false; // the dismiss already flipped visible off
 
-      expect(confirmMock.confirm).not.toHaveBeenCalled();
-      expect(component.showFileEditor).toBeFalse();
-    });
+    component.onFileEditorHide();
 
-    it('blocks a full-page leave only while there are unsaved edits', () => {
-      openEditor('hello');
-      const clean = {
-        preventDefault: jasmine.createSpy('preventDefault'),
-        returnValue: '',
-      } as unknown as BeforeUnloadEvent;
-      component.warnBeforeUnload(clean);
-      expect(clean.preventDefault).not.toHaveBeenCalled();
+    expect(component.showFileEditor).toBeTrue(); // reopened
+    expect(confirmMock.confirm).toHaveBeenCalledTimes(1);
+  });
 
-      component.fileContent = 'changed';
-      const dirty = {
-        preventDefault: jasmine.createSpy('preventDefault'),
-        returnValue: '',
-      } as unknown as BeforeUnloadEvent;
-      component.warnBeforeUnload(dirty);
-      expect(dirty.preventDefault).toHaveBeenCalled();
-    });
+  it('lets a clean dialog dismiss close with no prompt', () => {
+    openEditor('hello');
+    component.showFileEditor = false;
+
+    component.onFileEditorHide();
+
+    expect(confirmMock.confirm).not.toHaveBeenCalled();
+    expect(component.showFileEditor).toBeFalse();
+  });
+
+  it('blocks a full-page leave only while there are unsaved edits', () => {
+    openEditor('hello');
+    const clean = {
+      preventDefault: jasmine.createSpy('preventDefault'),
+      returnValue: '',
+    } as unknown as BeforeUnloadEvent;
+    component.warnBeforeUnload(clean);
+    expect(clean.preventDefault).not.toHaveBeenCalled();
+
+    component.fileContent = 'changed';
+    const dirty = {
+      preventDefault: jasmine.createSpy('preventDefault'),
+      returnValue: '',
+    } as unknown as BeforeUnloadEvent;
+    component.warnBeforeUnload(dirty);
+    expect(dirty.preventDefault).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/pages/cloud/cloud.component.spec.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -320,20 +320,92 @@ describe('CloudComponent File Checksum', () => {
     expect(component.hashMatchStatus).toBe('mismatch');
   });
 
-  it('should copy checksum to clipboard and set toast notification', () => {
-    component.checksumResult = {
-      filePath: 'doc.txt',
-      checksum: '1234567890abcdef',
-      algorithm: 'SHA-256',
-    };
+  describe('Clipboard Copy functionality', () => {
+    let originalClipboard: any;
 
-    component.copyChecksumToClipboard();
+    beforeEach(() => {
+      originalClipboard = navigator.clipboard;
+    });
 
-    expect(component.copiedHashState).toBeTrue();
-    expect(toastMock.success).toHaveBeenCalledWith(
-      'Checksum Copied',
-      jasmine.any(String),
-    );
+    afterEach(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: originalClipboard,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('should copy checksum to clipboard and set success toast notification on success', fakeAsync(() => {
+      component.checksumResult = {
+        filePath: 'doc.txt',
+        checksum: '1234567890abcdef',
+        algorithm: 'SHA-256',
+      };
+
+      const writeTextSpy = jasmine.createSpy('writeText').and.returnValue(Promise.resolve());
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: writeTextSpy },
+        configurable: true,
+        writable: true,
+      });
+
+      component.copyChecksumToClipboard();
+      tick();
+
+      expect(writeTextSpy).toHaveBeenCalledWith('1234567890abcdef');
+      expect(component.copiedHashState).toBeTrue();
+      expect(toastMock.success).toHaveBeenCalledWith(
+        'Checksum Copied',
+        jasmine.any(String),
+      );
+    }));
+
+    it('should handle clipboard writeText failure and show error toast', fakeAsync(() => {
+      component.checksumResult = {
+        filePath: 'doc.txt',
+        checksum: '1234567890abcdef',
+        algorithm: 'SHA-256',
+      };
+
+      const writeTextSpy = jasmine.createSpy('writeText').and.returnValue(Promise.reject('error'));
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: writeTextSpy },
+        configurable: true,
+        writable: true,
+      });
+
+      component.copyChecksumToClipboard();
+      tick();
+
+      expect(writeTextSpy).toHaveBeenCalledWith('1234567890abcdef');
+      expect(component.copiedHashState).toBeFalse();
+      expect(toastMock.error).toHaveBeenCalledWith(
+        'Copy Failed',
+        jasmine.any(String),
+      );
+    }));
+
+    it('should handle unsupported clipboard API and show error toast', () => {
+      component.checksumResult = {
+        filePath: 'doc.txt',
+        checksum: '1234567890abcdef',
+        algorithm: 'SHA-256',
+      };
+
+      Object.defineProperty(navigator, 'clipboard', {
+        value: undefined,
+        configurable: true,
+        writable: true,
+      });
+
+      component.copyChecksumToClipboard();
+
+      expect(component.copiedHashState).toBeFalse();
+      expect(toastMock.error).toHaveBeenCalledWith(
+        'Copy Failed',
+        jasmine.any(String),
+      );
+    });
   });
 });
 

--- a/frontend/src/app/pages/cloud/cloud.component.spec.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.spec.ts
@@ -1,4 +1,9 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -342,7 +347,9 @@ describe('CloudComponent File Checksum', () => {
         algorithm: 'SHA-256',
       };
 
-      const writeTextSpy = jasmine.createSpy('writeText').and.returnValue(Promise.resolve());
+      const writeTextSpy = jasmine
+        .createSpy('writeText')
+        .and.returnValue(Promise.resolve());
       Object.defineProperty(navigator, 'clipboard', {
         value: { writeText: writeTextSpy },
         configurable: true,
@@ -367,7 +374,9 @@ describe('CloudComponent File Checksum', () => {
         algorithm: 'SHA-256',
       };
 
-      const writeTextSpy = jasmine.createSpy('writeText').and.returnValue(Promise.reject('error'));
+      const writeTextSpy = jasmine
+        .createSpy('writeText')
+        .and.returnValue(Promise.reject('error'));
       Object.defineProperty(navigator, 'clipboard', {
         value: { writeText: writeTextSpy },
         configurable: true,

--- a/frontend/src/app/pages/cloud/cloud.component.spec.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.spec.ts
@@ -242,3 +242,97 @@ describe('CloudComponent virus scan', () => {
     expect(cloudMock.getScanJob).not.toHaveBeenCalled();
   });
 });
+
+describe('CloudComponent File Checksum', () => {
+  let component: CloudComponent;
+  let cloudMock: jasmine.SpyObj<CloudService>;
+  let toastMock: { success: jasmine.Spy; error: jasmine.Spy };
+
+  beforeEach(() => {
+    cloudMock = jasmine.createSpyObj<CloudService>('CloudService', [
+      'getFileChecksum',
+    ]);
+    toastMock = {
+      success: jasmine.createSpy('success'),
+      error: jasmine.createSpy('error'),
+    };
+    component = new CloudComponent(
+      cloudMock,
+      {} as never,
+      toastMock as never,
+      {} as never,
+      {} as never,
+    );
+    component.rootPath = '/root';
+  });
+
+  it('should open dialog and load file checksum successfully', () => {
+    const mockChecksum = {
+      filePath: 'test.pdf',
+      checksum:
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      algorithm: 'SHA-256',
+    };
+    cloudMock.getFileChecksum.and.returnValue(of(mockChecksum));
+
+    component.openChecksumDialog({
+      name: 'test.pdf',
+      path: '/root/test.pdf',
+    });
+
+    expect(component.showChecksumDialog).toBeTrue();
+    expect(component.selectedFileForChecksum?.name).toBe('test.pdf');
+    expect(component.checksumLoading).toBeFalse();
+    expect(component.checksumResult?.checksum).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    );
+  });
+
+  it('should handle checksum error and invoke toast notification', () => {
+    cloudMock.getFileChecksum.and.returnValue(
+      throwError(() => new Error('Checksum endpoint failure')),
+    );
+
+    component.openChecksumDialog({
+      name: 'corrupted.zip',
+      path: '/root/corrupted.zip',
+    });
+
+    expect(component.checksumLoading).toBeFalse();
+    expect(component.checksumError).toContain('Checksum endpoint failure');
+    expect(toastMock.error).toHaveBeenCalled();
+  });
+
+  it('should evaluate expected hash comparison correctly', () => {
+    component.checksumResult = {
+      filePath: 'doc.txt',
+      checksum: 'A1B2C3D4E5',
+      algorithm: 'SHA-256',
+    };
+
+    component.expectedHash = '';
+    expect(component.hashMatchStatus).toBe('empty');
+
+    component.expectedHash = 'a1b2c3d4e5';
+    expect(component.hashMatchStatus).toBe('match');
+
+    component.expectedHash = 'wronghash123';
+    expect(component.hashMatchStatus).toBe('mismatch');
+  });
+
+  it('should copy checksum to clipboard and set toast notification', () => {
+    component.checksumResult = {
+      filePath: 'doc.txt',
+      checksum: '1234567890abcdef',
+      algorithm: 'SHA-256',
+    };
+
+    component.copyChecksumToClipboard();
+
+    expect(component.copiedHashState).toBeTrue();
+    expect(toastMock.success).toHaveBeenCalledWith(
+      'Checksum Copied',
+      jasmine.any(String),
+    );
+  });
+});

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -28,6 +28,7 @@ import { FolderContentItemDto } from '../../models/dtos/FolderContentItemDto';
 import { SearchResultDto } from '../../models/dtos/SearchResultDto';
 import { ScanJobDto } from '../../models/dtos/ScanJobDto';
 import { FileScanResultDto } from '../../models/dtos/FileScanResultDto';
+import { FileChecksumDto } from '../../models/dtos/FileChecksumDto';
 import { CloudService } from '../../services/cloud.service';
 import { finalize, firstValueFrom } from 'rxjs';
 import { UiToastService } from '../../core/services/ui-toast.service';
@@ -128,6 +129,14 @@ export class CloudComponent implements OnInit, OnDestroy {
   // callbacks compare against it and bail if they've been superseded (mirrors
   // the contentRequestId guard used for folder loads/searches).
   private scanRunId = 0;
+
+  showChecksumDialog = false;
+  checksumLoading = false;
+  checksumError?: string;
+  checksumResult?: FileChecksumDto;
+  selectedFileForChecksum?: { name: string; path: string } | null;
+  expectedHash = '';
+  copiedHashState = false;
 
   pageSize = 50;
   totalElements = 0;
@@ -1273,5 +1282,54 @@ export class CloudComponent implements OnInit, OnDestroy {
     } else {
       this.downloadFile(file);
     }
+  }
+
+  openChecksumDialog(file: { path: string; name: string }): void {
+    this.selectedFileForChecksum = { name: file.name, path: file.path };
+    this.showChecksumDialog = true;
+    this.checksumLoading = true;
+    this.checksumError = undefined;
+    this.checksumResult = undefined;
+    this.expectedHash = '';
+    this.copiedHashState = false;
+
+    const relativePath = this.getRelativePath(file.path);
+    this.cloudService.getFileChecksum(relativePath).subscribe({
+      next: (result) => {
+        this.checksumResult = result;
+        this.checksumLoading = false;
+      },
+      error: (err) => {
+        this.checksumLoading = false;
+        const msg = this.getErrorMessage(err);
+        this.checksumError = msg;
+        this.toast.error('Checksum Calculation Failed', msg);
+      },
+    });
+  }
+
+  copyChecksumToClipboard(): void {
+    if (!this.checksumResult?.checksum) return;
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      navigator.clipboard
+        .writeText(this.checksumResult.checksum)
+        .catch(() => {});
+    }
+    this.copiedHashState = true;
+    this.toast.success(
+      'Checksum Copied',
+      'SHA-256 checksum copied to clipboard.',
+    );
+    setTimeout(() => {
+      this.copiedHashState = false;
+    }, 2000);
+  }
+
+  get hashMatchStatus(): 'empty' | 'match' | 'mismatch' {
+    if (!this.expectedHash || !this.expectedHash.trim()) return 'empty';
+    if (!this.checksumResult?.checksum) return 'empty';
+    const expected = this.expectedHash.trim().toLowerCase();
+    const computed = this.checksumResult.checksum.trim().toLowerCase();
+    return expected === computed ? 'match' : 'mismatch';
   }
 }

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -1541,10 +1541,7 @@ export class CloudComponent implements OnInit, OnDestroy {
           );
         });
     } else {
-      this.toast.error(
-        'Copy Failed',
-        'Clipboard API not supported.',
-      );
+      this.toast.error('Copy Failed', 'Clipboard API not supported.');
     }
   }
 

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -155,6 +155,7 @@ export class CloudComponent implements OnInit, OnDestroy {
   // the contentRequestId guard used for folder loads/searches).
   private scanRunId = 0;
 
+  private checksumRequestId = 0;
   showChecksumDialog = false;
   checksumLoading = false;
   checksumError?: string;
@@ -1478,6 +1479,8 @@ export class CloudComponent implements OnInit, OnDestroy {
   }
 
   openChecksumDialog(file: { path: string; name: string }): void {
+    if (!file) return;
+    const requestId = ++this.checksumRequestId;
     this.selectedFileForChecksum = { name: file.name, path: file.path };
     this.showChecksumDialog = true;
     this.checksumLoading = true;
@@ -1489,16 +1492,31 @@ export class CloudComponent implements OnInit, OnDestroy {
     const relativePath = this.getRelativePath(file.path);
     this.cloudService.getFileChecksum(relativePath).subscribe({
       next: (result) => {
+        if (requestId !== this.checksumRequestId || !this.showChecksumDialog)
+          return;
         this.checksumResult = result;
         this.checksumLoading = false;
       },
       error: (err) => {
+        if (requestId !== this.checksumRequestId || !this.showChecksumDialog)
+          return;
         this.checksumLoading = false;
         const msg = this.getErrorMessage(err);
         this.checksumError = msg;
         this.toast.error('Checksum Calculation Failed', msg);
       },
     });
+  }
+
+  onChecksumDialogHide(): void {
+    this.checksumRequestId++;
+    this.showChecksumDialog = false;
+    this.checksumLoading = false;
+    this.checksumError = undefined;
+    this.checksumResult = undefined;
+    this.selectedFileForChecksum = null;
+    this.expectedHash = '';
+    this.copiedHashState = false;
   }
 
   copyChecksumToClipboard(): void {

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -1524,16 +1524,28 @@ export class CloudComponent implements OnInit, OnDestroy {
     if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
       navigator.clipboard
         .writeText(this.checksumResult.checksum)
-        .catch(() => {});
+        .then(() => {
+          this.copiedHashState = true;
+          this.toast.success(
+            'Checksum Copied',
+            'SHA-256 checksum copied to clipboard.',
+          );
+          setTimeout(() => {
+            this.copiedHashState = false;
+          }, 2000);
+        })
+        .catch(() => {
+          this.toast.error(
+            'Copy Failed',
+            'Failed to copy checksum to clipboard.',
+          );
+        });
+    } else {
+      this.toast.error(
+        'Copy Failed',
+        'Clipboard API not supported.',
+      );
     }
-    this.copiedHashState = true;
-    this.toast.success(
-      'Checksum Copied',
-      'SHA-256 checksum copied to clipboard.',
-    );
-    setTimeout(() => {
-      this.copiedHashState = false;
-    }, 2000);
   }
 
   get hashMatchStatus(): 'empty' | 'match' | 'mismatch' {

--- a/frontend/src/app/services/cloud.service.spec.ts
+++ b/frontend/src/app/services/cloud.service.spec.ts
@@ -1,0 +1,67 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { CloudService } from './cloud.service';
+
+describe('CloudService Checksum', () => {
+  let service: CloudService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [CloudService],
+    });
+
+    service = TestBed.inject(CloudService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should fetch file checksum from /files/checksum endpoint', (done) => {
+    const mockResponse = {
+      filePath: 'test.pdf',
+      checksum:
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      algorithm: 'SHA-256',
+    };
+
+    service.getFileChecksum('test.pdf').subscribe((res) => {
+      expect(res.checksum).toBe(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      );
+      expect(res.algorithm).toBe('SHA-256');
+      done();
+    });
+
+    const req = httpMock.expectOne((request) =>
+      request.url.endsWith('/files/checksum'),
+    );
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('path')).toBe('test.pdf');
+    req.flush(mockResponse);
+  });
+
+  it('should support alternative property names (e.g. hash or sha256)', (done) => {
+    const mockResponse = {
+      hash: 'abc123sha256hash',
+    };
+
+    service.getFileChecksum('docs/file.txt').subscribe((res) => {
+      expect(res.checksum).toBe('abc123sha256hash');
+      expect(res.algorithm).toBe('SHA-256');
+      done();
+    });
+
+    const req = httpMock.expectOne((request) =>
+      request.url.endsWith('/files/checksum'),
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(mockResponse);
+  });
+});

--- a/frontend/src/app/services/cloud.service.ts
+++ b/frontend/src/app/services/cloud.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { FolderDto } from '../models/dtos/FolderDto';
 import { FolderContentItemDto } from '../models/dtos/FolderContentItemDto';
 import { PageResponseDto } from '../models/dtos/PageResponseDto';
 import { TrashEntryDto } from '../models/dtos/TrashEntryDto';
 import { SearchResultDto } from '../models/dtos/SearchResultDto';
 import { ScanJobDto } from '../models/dtos/ScanJobDto';
+import { FileChecksumDto } from '../models/dtos/FileChecksumDto';
 import { environment } from '../../environments/environment';
 
 @Injectable({
@@ -185,5 +186,36 @@ export class CloudService {
     return this.http.get<ScanJobDto>(
       `${this.apiUrl}/files/scan/${encodeURIComponent(jobId)}`,
     );
+  }
+
+  getFileChecksum(filePath: string): Observable<FileChecksumDto> {
+    const normPath = this.normalizePath(filePath);
+    const params = new HttpParams().set('path', normPath);
+    return this.http
+      .get<unknown>(`${this.apiUrl}/files/checksum`, { params })
+      .pipe(
+        map((res) => {
+          const raw = res as
+            | {
+                checksum?: string;
+                hash?: string;
+                sha256?: string;
+                value?: string;
+                algorithm?: string;
+              }
+            | string;
+          const checksum =
+            typeof raw === 'string'
+              ? raw
+              : raw?.checksum || raw?.hash || raw?.sha256 || raw?.value || '';
+          const algorithm =
+            (typeof raw === 'object' && raw?.algorithm) || 'SHA-256';
+          return {
+            filePath: normPath,
+            checksum,
+            algorithm,
+          };
+        }),
+      );
   }
 }


### PR DESCRIPTION
## 📌 Description
This PR resolves **#282** by adding a complete file integrity verification feature to the Cloud page UI. Users can now compute, view, copy, and compare the SHA-256 checksum of any stored file directly from the Cloud interface.

---

## 🚀 Key Changes

### 1. Service Layer & DTO (`CloudService` & `FileChecksumDto`)
- Created `FileChecksumDto` (`filePath`, `checksum`, `algorithm`).
- Added `getFileChecksum(filePath: string)` method in `CloudService` consuming the backend SHA-256 checksum endpoint (`GET /api/files/checksum?path=...`).
- Added flexible property mapping to gracefully handle variations in backend response formats (`checksum`, `hash`, `sha256`).

### 2. UI Action & Checksum Dialog (`CloudComponent`)
- **Per-File Action Button**: Added a dedicated *"Verify file integrity (SHA-256)"* action button (`pi pi-shield`) to every file entry row in the Cloud file browser table.
- **File Integrity Dialog (`p-dialog`)**:
  - **Header & Path**: Displays file name and full relative path.
  - **Loading State**: Shows a dedicated spinner and status text while large files are being hashed by the backend.
  - **Formatted Hash Display**: Displays computed SHA-256 hash in a monospace block for visual clarity.
  - **Clipboard Copy**: One-click copy button (`pi pi-copy`) with instant `UiToastService` feedback.
  - **Hash Verification**: Allows users to paste an expected SHA-256 hash
