### PR TITLE
feat(cloud): warn before leaving unsaved file edits

### DIFF
--- a/frontend/src/app/pages/cloud/cloud.component.html
+++ b/frontend/src/app/pages/cloud/cloud.component.html
@@ -367,7 +367,7 @@
 
   <p-dialog
     [(visible)]="showFileEditor"
-    (onHide)="closeFileEditor()"
+    (onHide)="onFileEditorHide()"
     [modal]="true"
     [closable]="true"
     [draggable]="false"
@@ -474,7 +474,7 @@
       <p-button
         label="Cancel"
         styleClass="p-button-text p-button-sm text-xxs sm:text-xs"
-        (click)="closeFileEditor()"
+        (click)="requestCloseFileEditor()"
       ></p-button>
       <p-button
         label="Save"

--- a/frontend/src/app/pages/cloud/cloud.component.spec.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.spec.ts
@@ -409,9 +409,11 @@ describe('CloudComponent unsaved-edit guard', () => {
     );
   });
 
-  // Open the editor on a file whose loaded content is `content` (not yet dirty).
-  function openEditor(content: string): void {
+  // Open the editor on a file whose loaded state is not yet dirty.
+  function openEditor(content: string, fileName = 'note.txt'): void {
     component.showFileEditor = true;
+    component.newFileName = fileName;
+    component.originalFileName = fileName;
     component.fileContent = content;
     component.originalFileContent = content;
   }
@@ -441,6 +443,16 @@ describe('CloudComponent unsaved-edit guard', () => {
     acceptLastConfirm();
     expect(component.showFileEditor).toBeFalse();
     expect(component.fileContent).toBe(''); // editor state fully reset
+  });
+
+  it('asks before discarding when only the file name changed', () => {
+    openEditor('hello', 'old.txt');
+    component.newFileName = 'new.txt';
+
+    component.requestCloseFileEditor();
+
+    expect(confirmMock.confirm).toHaveBeenCalledTimes(1);
+    expect(component.showFileEditor).toBeTrue();
   });
 
   it('reverses a dialog dismiss and confirms when there are unsaved edits', () => {

--- a/frontend/src/app/pages/cloud/cloud.component.spec.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.spec.ts
@@ -388,3 +388,97 @@ describe('CloudComponent Secure Send Flow', () => {
     );
   });
 });
+
+/**
+ * The unsaved-changes guard on the Cloud file editor: every exit path (Cancel,
+ * the dialog dismiss, and a full-page leave) must confirm before discarding
+ * edits, and a clean editor must close without a prompt.
+ */
+describe('CloudComponent unsaved-edit guard', () => {
+  let component: CloudComponent;
+  let confirmMock: jasmine.SpyObj<{ confirm: (config: unknown) => void }>;
+
+  beforeEach(() => {
+    confirmMock = jasmine.createSpyObj('ConfirmationService', ['confirm']);
+    component = new CloudComponent(
+      {} as never,
+      confirmMock as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+  });
+
+  // Open the editor on a file whose loaded content is `content` (not yet dirty).
+  function openEditor(content: string): void {
+    component.showFileEditor = true;
+    component.fileContent = content;
+    component.originalFileContent = content;
+  }
+
+  function acceptLastConfirm(): void {
+    const config = confirmMock.confirm.calls.mostRecent().args[0] as {
+      accept: () => void;
+    };
+    config.accept();
+  }
+
+  it('closes without asking when the editor has no unsaved edits', () => {
+    openEditor('hello');
+    component.requestCloseFileEditor();
+    expect(confirmMock.confirm).not.toHaveBeenCalled();
+    expect(component.showFileEditor).toBeFalse();
+  });
+
+  it('asks before discarding, and only closes once Discard is confirmed', () => {
+    openEditor('hello');
+    component.fileContent = 'hello world'; // dirty
+
+    component.requestCloseFileEditor();
+    expect(confirmMock.confirm).toHaveBeenCalledTimes(1);
+    expect(component.showFileEditor).toBeTrue(); // stays open until confirmed
+
+    acceptLastConfirm();
+    expect(component.showFileEditor).toBeFalse();
+    expect(component.fileContent).toBe(''); // editor state fully reset
+  });
+
+  it('reverses a dialog dismiss and confirms when there are unsaved edits', () => {
+    openEditor('hello');
+    component.fileContent = 'changed';
+    component.showFileEditor = false; // the dismiss already flipped visible off
+
+    component.onFileEditorHide();
+
+    expect(component.showFileEditor).toBeTrue(); // reopened
+    expect(confirmMock.confirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a clean dialog dismiss close with no prompt', () => {
+    openEditor('hello');
+    component.showFileEditor = false;
+
+    component.onFileEditorHide();
+
+    expect(confirmMock.confirm).not.toHaveBeenCalled();
+    expect(component.showFileEditor).toBeFalse();
+  });
+
+  it('blocks a full-page leave only while there are unsaved edits', () => {
+    openEditor('hello');
+    const clean = {
+      preventDefault: jasmine.createSpy('preventDefault'),
+      returnValue: '',
+    } as unknown as BeforeUnloadEvent;
+    component.warnBeforeUnload(clean);
+    expect(clean.preventDefault).not.toHaveBeenCalled();
+
+    component.fileContent = 'changed';
+    const dirty = {
+      preventDefault: jasmine.createSpy('preventDefault'),
+      returnValue: '',
+    } as unknown as BeforeUnloadEvent;
+    component.warnBeforeUnload(dirty);
+    expect(dirty.preventDefault).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -89,7 +89,8 @@ export class CloudComponent implements OnInit, OnDestroy {
   editingFile: FileDto | null = null;
   newFileName = '';
   fileContent = '';
-  // The content as last loaded/saved — the editor is "dirty" when fileContent diverges.
+  // The editor state as last loaded or saved.
+  originalFileName = '';
   originalFileContent = '';
   editorMode: 'edit' | 'preview' | 'split' = 'edit';
   previewHtml: SafeHtml = '';
@@ -690,6 +691,7 @@ export class CloudComponent implements OnInit, OnDestroy {
     this.editingFile = null;
     this.newFileName = '';
     this.fileContent = '';
+    this.originalFileName = '';
     this.originalFileContent = '';
     this.editorMode = 'edit';
     this.previewHtml = '';
@@ -736,6 +738,7 @@ export class CloudComponent implements OnInit, OnDestroy {
 
     this.editingFile = file;
     this.newFileName = file.name;
+    this.originalFileName = file.name;
     const relativePath = this.getRelativePath(file.path);
 
     this.cloudService.getFileContent(relativePath).subscribe({
@@ -1024,6 +1027,7 @@ export class CloudComponent implements OnInit, OnDestroy {
     this.editingFile = null;
     this.newFileName = '';
     this.fileContent = '';
+    this.originalFileName = '';
     this.originalFileContent = '';
     this.editorMode = 'edit';
     this.previewHtml = '';
@@ -1031,7 +1035,14 @@ export class CloudComponent implements OnInit, OnDestroy {
 
   /** True while the editor is open with edits that have not been saved. */
   get isEditorDirty(): boolean {
-    return this.showFileEditor && this.fileContent !== this.originalFileContent;
+    return this.showFileEditor && this.hasUnsavedEditorChanges();
+  }
+
+  private hasUnsavedEditorChanges(): boolean {
+    return (
+      this.fileContent !== this.originalFileContent ||
+      this.newFileName !== this.originalFileName
+    );
   }
 
   /**
@@ -1040,7 +1051,7 @@ export class CloudComponent implements OnInit, OnDestroy {
    * changes.
    */
   requestCloseFileEditor(): void {
-    if (!this.isEditorDirty) {
+    if (!this.hasUnsavedEditorChanges()) {
       this.closeFileEditor();
       return;
     }
@@ -1062,7 +1073,7 @@ export class CloudComponent implements OnInit, OnDestroy {
    * route through the same guard so a dismiss can't bypass the prompt.
    */
   onFileEditorHide(): void {
-    if (this.fileContent === this.originalFileContent) {
+    if (!this.hasUnsavedEditorChanges()) {
       this.closeFileEditor();
       return;
     }

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import {
   Component,
   ElementRef,
+  HostListener,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -88,6 +89,8 @@ export class CloudComponent implements OnInit, OnDestroy {
   editingFile: FileDto | null = null;
   newFileName = '';
   fileContent = '';
+  // The content as last loaded/saved — the editor is "dirty" when fileContent diverges.
+  originalFileContent = '';
   editorMode: 'edit' | 'preview' | 'split' = 'edit';
   previewHtml: SafeHtml = '';
 
@@ -687,6 +690,7 @@ export class CloudComponent implements OnInit, OnDestroy {
     this.editingFile = null;
     this.newFileName = '';
     this.fileContent = '';
+    this.originalFileContent = '';
     this.editorMode = 'edit';
     this.previewHtml = '';
     this.showFileEditor = true;
@@ -737,6 +741,7 @@ export class CloudComponent implements OnInit, OnDestroy {
     this.cloudService.getFileContent(relativePath).subscribe({
       next: (content) => {
         this.fileContent = content;
+        this.originalFileContent = content;
         this.editorMode = 'edit';
         this.updatePreview();
         this.showFileEditor = true;
@@ -1019,8 +1024,59 @@ export class CloudComponent implements OnInit, OnDestroy {
     this.editingFile = null;
     this.newFileName = '';
     this.fileContent = '';
+    this.originalFileContent = '';
     this.editorMode = 'edit';
     this.previewHtml = '';
+  }
+
+  /** True while the editor is open with edits that have not been saved. */
+  get isEditorDirty(): boolean {
+    return this.showFileEditor && this.fileContent !== this.originalFileContent;
+  }
+
+  /**
+   * Close the editor, but if there are unsaved edits ask first. Used by the
+   * Cancel button and by the dialog's dismiss paths so no exit silently drops
+   * changes.
+   */
+  requestCloseFileEditor(): void {
+    if (!this.isEditorDirty) {
+      this.closeFileEditor();
+      return;
+    }
+    this.confirmationService.confirm({
+      header: 'Unsaved changes',
+      message: 'Exit without saving? Your changes will be lost.',
+      icon: 'pi pi-exclamation-triangle',
+      acceptLabel: 'Discard',
+      rejectLabel: 'Keep editing',
+      acceptButtonStyleClass: 'p-button-danger p-button-sm',
+      rejectButtonStyleClass: 'p-button-text p-button-sm',
+      accept: () => this.closeFileEditor(),
+    });
+  }
+
+  /**
+   * The dialog was dismissed (the header close button, Esc, or a mask click),
+   * which the two-way visible binding has already flipped off. Reverse it and
+   * route through the same guard so a dismiss can't bypass the prompt.
+   */
+  onFileEditorHide(): void {
+    if (this.fileContent === this.originalFileContent) {
+      this.closeFileEditor();
+      return;
+    }
+    this.showFileEditor = true;
+    this.requestCloseFileEditor();
+  }
+
+  /** Native guard for a full-page leave (reload, tab close, external navigation). */
+  @HostListener('window:beforeunload', ['$event'])
+  warnBeforeUnload(event: BeforeUnloadEvent): void {
+    if (this.isEditorDirty) {
+      event.preventDefault();
+      event.returnValue = '';
+    }
   }
 
   openCreateShareDialog(filePath: string, fileName: string) {


### PR DESCRIPTION
## What

Closes #261. The Cloud file editor could be left with unsaved changes and the edits were discarded silently — closing the dialog (the ✕, `Esc`, or a mask click), clicking **Cancel**, or leaving the page.

## How

Track the content as loaded (`originalFileContent`); the editor is *dirty* when `fileContent` diverges. Every exit path now routes through one guard, `requestCloseFileEditor()`, which asks before discarding:

> Exit without saving? Your changes will be lost.  — **Discard** / **Keep editing**

- **Cancel** → `requestCloseFileEditor()`
- **dialog dismiss** (✕ / `Esc` / mask) → `onFileEditorHide()` reverses the dismiss and routes through the same guard, so it can't sneak past the prompt
- **full-page leave** (reload, tab close, external nav) → a `window:beforeunload` guard
- a **clean** editor closes with no prompt, and **Save** is unaffected

Reuses the existing `ConfirmationService` / `<p-confirmdialog>` already used for delete confirmations — no new dependency.

## Testing

`ng test` — 5 new specs in `cloud.component.spec.ts` cover every path: clean close (no prompt), dirty Cancel (prompt, closes only on Discard), dirty dismiss (reopens + prompts), clean dismiss, and the unload guard firing only while dirty. Full suite green (22), `ng build` and Prettier clean.
