### PR TITLE
feat(portal): add dynamic service registry with manifest integration (#278)

### DIFF
--- a/docs/service-manifest-schema.md
+++ b/docs/service-manifest-schema.md
@@ -1,0 +1,94 @@
+# Vault Web Service Manifest Schema
+
+This document defines the standard JSON schema for external service dynamic integration manifests (`vault-service.json`).
+
+Each service module in the Vault Web ecosystem (e.g. Cloud, Password Manager, Chats, Habits) must ship a conformant manifest file at its web root.
+
+## Schema Definition
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "VaultServiceManifest",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Unique identifier of the service module (e.g. 'cloud')."
+    },
+    "displayName": {
+      "type": "string",
+      "description": "Human-readable name displayed in menus (e.g. 'Cloud')."
+    },
+    "icon": {
+      "type": "string",
+      "description": "PrimeIcons class name for navigation icons (e.g. 'pi-cloud')."
+    },
+    "route": {
+      "type": "string",
+      "description": "Local Angular route to activate the service view (e.g. '/cloud')."
+    },
+    "baseUrl": {
+      "type": "string",
+      "description": "Base URL where the service module is deployed (e.g. 'http://localhost:8090')."
+    },
+    "healthEndpoint": {
+      "type": "string",
+      "description": "Endpoint path to verify the module's operational state (e.g. 'http://localhost:8090/api/health')."
+    },
+    "requiredScopes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Required OAuth2/JWT scopes for interacting with this service."
+    },
+    "tokenForwarding": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the API gateway should forward the portal token to this service."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["header", "cookie", "query"],
+          "description": "Method of token transmission."
+        },
+        "name": {
+          "type": "string",
+          "description": "Header, cookie, or query parameter name for the token."
+        }
+      },
+      "required": ["enabled"]
+    }
+  },
+  "required": [
+    "name",
+    "displayName",
+    "icon",
+    "route",
+    "baseUrl",
+    "healthEndpoint"
+  ]
+}
+```
+
+## Example Manifest (`vault-service.json`)
+
+```json
+{
+  "name": "cloud",
+  "displayName": "Cloud",
+  "icon": "pi-cloud",
+  "route": "/cloud",
+  "baseUrl": "http://localhost:8090",
+  "healthEndpoint": "http://localhost:8090/api/health",
+  "requiredScopes": ["cloud:read", "cloud:write"],
+  "tokenForwarding": {
+    "enabled": true,
+    "type": "header",
+    "name": "Authorization"
+  }
+}
+```

--- a/frontend/public/cloud-service.json
+++ b/frontend/public/cloud-service.json
@@ -1,0 +1,14 @@
+{
+  "name": "cloud",
+  "displayName": "Cloud",
+  "icon": "pi-cloud",
+  "route": "/cloud",
+  "baseUrl": "http://localhost:8090",
+  "healthEndpoint": "http://localhost:8090/api/health",
+  "requiredScopes": ["cloud:read", "cloud:write"],
+  "tokenForwarding": {
+    "enabled": true,
+    "type": "header",
+    "name": "Authorization"
+  }
+}

--- a/frontend/public/cloud-service.json
+++ b/frontend/public/cloud-service.json
@@ -3,8 +3,9 @@
   "displayName": "Cloud",
   "icon": "pi-cloud",
   "route": "/cloud",
-  "baseUrl": "http://localhost:8090",
-  "healthEndpoint": "http://localhost:8090/api/health",
+  "baseUrl": "http://{host}:8090",
+  "apiUrl": "http://{host}:8090/api",
+  "healthEndpoint": "http://{host}:8090/api/health",
   "requiredScopes": ["cloud:read", "cloud:write"],
   "tokenForwarding": {
     "enabled": true,

--- a/frontend/public/habits-service.json
+++ b/frontend/public/habits-service.json
@@ -2,7 +2,7 @@
   "name": "habits",
   "displayName": "Habits",
   "icon": "pi-calendar-plus",
-  "route": "http://{host}:8092",
+  "route": "/habits",
   "baseUrl": "http://{host}:8092",
   "apiUrl": "http://{host}:8092/api",
   "healthEndpoint": "http://{host}:8092/api/health",

--- a/frontend/public/habits-service.json
+++ b/frontend/public/habits-service.json
@@ -1,0 +1,14 @@
+{
+  "name": "habits",
+  "displayName": "Habits",
+  "icon": "pi-calendar-plus",
+  "route": "/habits",
+  "baseUrl": "http://localhost:8092",
+  "healthEndpoint": "http://localhost:8092/api/health",
+  "requiredScopes": ["habits:read"],
+  "tokenForwarding": {
+    "enabled": true,
+    "type": "header",
+    "name": "Authorization"
+  }
+}

--- a/frontend/public/habits-service.json
+++ b/frontend/public/habits-service.json
@@ -2,9 +2,10 @@
   "name": "habits",
   "displayName": "Habits",
   "icon": "pi-calendar-plus",
-  "route": "/habits",
-  "baseUrl": "http://localhost:8092",
-  "healthEndpoint": "http://localhost:8092/api/health",
+  "route": "http://{host}:8092",
+  "baseUrl": "http://{host}:8092",
+  "apiUrl": "http://{host}:8092/api",
+  "healthEndpoint": "http://{host}:8092/api/health",
   "requiredScopes": ["habits:read"],
   "tokenForwarding": {
     "enabled": true,

--- a/frontend/public/password-manager-service.json
+++ b/frontend/public/password-manager-service.json
@@ -3,8 +3,9 @@
   "displayName": "Password Manager",
   "icon": "pi-key",
   "route": "/passwords",
-  "baseUrl": "http://localhost:8091",
-  "healthEndpoint": "http://localhost:8091/api/health",
+  "baseUrl": "http://{host}:8091",
+  "apiUrl": "http://{host}:8091/api",
+  "healthEndpoint": "http://{host}:8091/api/health",
   "requiredScopes": ["passwords:read", "passwords:write"],
   "tokenForwarding": {
     "enabled": true,

--- a/frontend/public/password-manager-service.json
+++ b/frontend/public/password-manager-service.json
@@ -1,0 +1,14 @@
+{
+  "name": "passwords",
+  "displayName": "Password Manager",
+  "icon": "pi-key",
+  "route": "/passwords",
+  "baseUrl": "http://localhost:8091",
+  "healthEndpoint": "http://localhost:8091/api/health",
+  "requiredScopes": ["passwords:read", "passwords:write"],
+  "tokenForwarding": {
+    "enabled": true,
+    "type": "header",
+    "name": "Authorization"
+  }
+}

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,4 +1,8 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import {
+  ApplicationConfig,
+  provideZoneChangeDetection,
+  APP_INITIALIZER,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { providePrimeNG } from 'primeng/config';
@@ -6,6 +10,17 @@ import { MessageService } from 'primeng/api';
 import Aura from '@primeuix/themes/aura';
 import { routes } from './app.routes';
 import { tokenInterceptor } from './core/interceptors/token.interceptor';
+import { ServiceRegistryService } from './services/service-registry.service';
+import { firstValueFrom } from 'rxjs';
+
+export function initializeServices(registry: ServiceRegistryService) {
+  return () =>
+    firstValueFrom(registry.loadServices())
+      .then(() => firstValueFrom(registry.checkServicesHealth()))
+      .catch((err) => {
+        console.error('Service registry initialization failed', err);
+      });
+}
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -22,5 +37,11 @@ export const appConfig: ApplicationConfig = {
       },
     }),
     MessageService,
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializeServices,
+      deps: [ServiceRegistryService],
+      multi: true,
+    },
   ],
 };

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -16,7 +16,9 @@ import { firstValueFrom } from 'rxjs';
 export function initializeServices(registry: ServiceRegistryService) {
   return () =>
     firstValueFrom(registry.loadServices())
-      .then(() => firstValueFrom(registry.checkServicesHealth()))
+      .then(() => {
+        registry.checkServicesHealth().subscribe();
+      })
       .catch((err) => {
         console.error('Service registry initialization failed', err);
       });

--- a/frontend/src/app/navbar/navbar.component.html
+++ b/frontend/src/app/navbar/navbar.component.html
@@ -57,14 +57,24 @@
           >Dashboard</a
         >
         <ng-container *ngFor="let service of services">
-          <a
-            *ngIf="service.isAvailable; else offlineLink"
-            [routerLink]="service.route"
-            class="navbar-link"
-            routerLinkActive="is-active"
-          >
-            {{ service.displayName }}
-          </a>
+          <ng-container *ngIf="service.isAvailable; else offlineLink">
+            <a
+              *ngIf="isExternalUrl(service.route); else internalLink"
+              [href]="service.route"
+              class="navbar-link"
+            >
+              {{ service.displayName }}
+            </a>
+            <ng-template #internalLink>
+              <a
+                [routerLink]="service.route"
+                class="navbar-link"
+                routerLinkActive="is-active"
+              >
+                {{ service.displayName }}
+              </a>
+            </ng-template>
+          </ng-container>
           <ng-template #offlineLink>
             <span
               class="navbar-link opacity-50 cursor-not-allowed flex items-center"
@@ -161,15 +171,26 @@
       >Dashboard</a
     >
     <ng-container *ngFor="let service of services">
-      <a
-        *ngIf="service.isAvailable; else offlineMobileLink"
-        [routerLink]="service.route"
-        (click)="closeMobileMenu()"
-        class="mobile-link block py-2"
-        routerLinkActive="is-active"
-      >
-        {{ service.displayName }}
-      </a>
+      <ng-container *ngIf="service.isAvailable; else offlineMobileLink">
+        <a
+          *ngIf="isExternalUrl(service.route); else internalMobileLink"
+          [href]="service.route"
+          (click)="closeMobileMenu()"
+          class="mobile-link block py-2"
+        >
+          {{ service.displayName }}
+        </a>
+        <ng-template #internalMobileLink>
+          <a
+            [routerLink]="service.route"
+            (click)="closeMobileMenu()"
+            class="mobile-link block py-2"
+            routerLinkActive="is-active"
+          >
+            {{ service.displayName }}
+          </a>
+        </ng-template>
+      </ng-container>
       <ng-template #offlineMobileLink>
         <span
           class="mobile-link block py-2 opacity-50 cursor-not-allowed"

--- a/frontend/src/app/navbar/navbar.component.html
+++ b/frontend/src/app/navbar/navbar.component.html
@@ -56,15 +56,29 @@
           routerLinkActive="is-active"
           >Dashboard</a
         >
-        <a routerLink="/cloud" class="navbar-link" routerLinkActive="is-active"
-          >Cloud</a
-        >
-        <a
-          routerLink="/passwords"
-          class="navbar-link"
-          routerLinkActive="is-active"
-          >Password Manager</a
-        >
+        <ng-container *ngFor="let service of services">
+          <a
+            *ngIf="service.isAvailable; else offlineLink"
+            [routerLink]="service.route"
+            class="navbar-link"
+            routerLinkActive="is-active"
+          >
+            {{ service.displayName }}
+          </a>
+          <ng-template #offlineLink>
+            <span
+              class="navbar-link opacity-50 cursor-not-allowed flex items-center"
+              [title]="service.displayName + ' is currently offline'"
+            >
+              {{ service.displayName }}
+              <span
+                class="bg-red-500 text-white rounded ml-1"
+                style="font-size: 0.6rem; padding: 1px 4px; line-height: 1"
+                >offline</span
+              >
+            </span>
+          </ng-template>
+        </ng-container>
         <a
           routerLink="/security-activity"
           class="navbar-link"
@@ -146,20 +160,30 @@
       routerLinkActive="is-active"
       >Dashboard</a
     >
-    <a
-      routerLink="/cloud"
-      (click)="closeMobileMenu()"
-      class="mobile-link block py-2"
-      routerLinkActive="is-active"
-      >Cloud</a
-    >
-    <a
-      routerLink="/passwords"
-      (click)="closeMobileMenu()"
-      class="mobile-link block py-2"
-      routerLinkActive="is-active"
-      >Password Manager</a
-    >
+    <ng-container *ngFor="let service of services">
+      <a
+        *ngIf="service.isAvailable; else offlineMobileLink"
+        [routerLink]="service.route"
+        (click)="closeMobileMenu()"
+        class="mobile-link block py-2"
+        routerLinkActive="is-active"
+      >
+        {{ service.displayName }}
+      </a>
+      <ng-template #offlineMobileLink>
+        <span
+          class="mobile-link block py-2 opacity-50 cursor-not-allowed"
+          [title]="service.displayName + ' is currently offline'"
+        >
+          {{ service.displayName }}
+          <span
+            class="bg-red-500 text-white rounded ml-1"
+            style="font-size: 0.6rem; padding: 1px 4px; line-height: 1"
+            >offline</span
+          >
+        </span>
+      </ng-template>
+    </ng-container>
     <a
       routerLink="/security-activity"
       (click)="closeMobileMenu()"

--- a/frontend/src/app/navbar/navbar.component.ts
+++ b/frontend/src/app/navbar/navbar.component.ts
@@ -9,6 +9,10 @@ import {
   ExternalDomainLink,
   resolveExternalLinkUrl,
 } from '../config/external-domains.config';
+import {
+  ServiceRegistryService,
+  ServiceManifest,
+} from '../services/service-registry.service';
 
 @Component({
   selector: 'app-navbar',
@@ -21,6 +25,7 @@ export class NavbarComponent implements OnInit {
   isMobileMenuOpen = false;
   isDomainDropdownOpen = false;
   readonly externalDomainLinks: ExternalDomainLink[] = EXTERNAL_DOMAIN_LINKS;
+  services: ServiceManifest[] = [];
 
   // Stores the full URL to the profile picture (e.g. "http://localhost:8080/uploads/...")
   // null means no picture is set — the template will show the fallback initial instead
@@ -30,12 +35,14 @@ export class NavbarComponent implements OnInit {
     public themeService: ThemeService,
     public authService: AuthService,
     private userService: UserService,
+    private serviceRegistry: ServiceRegistryService,
   ) {}
 
   /**
    * Loads the profile picture when the navbar initializes.
    */
   ngOnInit(): void {
+    this.services = this.serviceRegistry.getServices();
     if (this.authService.isLoggedIn()) {
       // Subscribe to reactive profile picture updates
       this.userService.profilePicUrl$.subscribe((url) => {

--- a/frontend/src/app/navbar/navbar.component.ts
+++ b/frontend/src/app/navbar/navbar.component.ts
@@ -42,7 +42,9 @@ export class NavbarComponent implements OnInit {
    * Loads the profile picture when the navbar initializes.
    */
   ngOnInit(): void {
-    this.services = this.serviceRegistry.getServices();
+    this.serviceRegistry.services$.subscribe((services) => {
+      this.services = services;
+    });
     if (this.authService.isLoggedIn()) {
       // Subscribe to reactive profile picture updates
       this.userService.profilePicUrl$.subscribe((url) => {
@@ -55,6 +57,10 @@ export class NavbarComponent implements OnInit {
         },
       });
     }
+  }
+
+  isExternalUrl(url: string): boolean {
+    return !!url && (url.startsWith('http://') || url.startsWith('https://'));
   }
 
   /**

--- a/frontend/src/app/services/service-registry.service.spec.ts
+++ b/frontend/src/app/services/service-registry.service.spec.ts
@@ -54,7 +54,7 @@ describe('ServiceRegistryService', () => {
       name: 'habits',
       displayName: 'Habits',
       icon: 'pi-calendar-plus',
-      route: 'http://{host}:8092',
+      route: '/habits',
       baseUrl: 'http://{host}:8092',
       apiUrl: 'http://{host}:8092/api',
       healthEndpoint: 'http://{host}:8092/api/health',

--- a/frontend/src/app/services/service-registry.service.spec.ts
+++ b/frontend/src/app/services/service-registry.service.spec.ts
@@ -1,0 +1,146 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import {
+  ServiceRegistryService,
+  ServiceManifest,
+} from './service-registry.service';
+
+describe('ServiceRegistryService', () => {
+  let service: ServiceRegistryService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ServiceRegistryService],
+    });
+    service = TestBed.inject(ServiceRegistryService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should load service manifests dynamically', () => {
+    const mockCloudManifest: ServiceManifest = {
+      name: 'cloud',
+      displayName: 'Cloud',
+      icon: 'pi-cloud',
+      route: '/cloud',
+      baseUrl: 'http://localhost:8090',
+      apiUrl: 'http://localhost:8090/api',
+      healthEndpoint: 'http://localhost:8090/api/health',
+    };
+
+    const mockPMManifest: ServiceManifest = {
+      name: 'passwords',
+      displayName: 'Password Manager',
+      icon: 'pi-key',
+      route: '/passwords',
+      baseUrl: 'http://localhost:8091',
+      apiUrl: 'http://localhost:8091/api',
+      healthEndpoint: 'http://localhost:8091/api/health',
+    };
+
+    const mockHabitsManifest: ServiceManifest = {
+      name: 'habits',
+      displayName: 'Habits',
+      icon: 'pi-calendar-plus',
+      route: '/habits',
+      baseUrl: 'http://localhost:8092',
+      apiUrl: 'http://localhost:8092/api',
+      healthEndpoint: 'http://localhost:8092/api/health',
+    };
+
+    service.loadServices().subscribe((loaded) => {
+      expect(loaded.length).toBe(3);
+      expect(loaded[0].name).toBe('cloud');
+      expect(loaded[1].name).toBe('passwords');
+      expect(loaded[2].name).toBe('habits');
+    });
+
+    const reqs = [
+      httpMock.expectOne('/cloud-service.json'),
+      httpMock.expectOne('/password-manager-service.json'),
+      httpMock.expectOne('/habits-service.json'),
+    ];
+
+    reqs[0].flush(mockCloudManifest);
+    reqs[1].flush(mockPMManifest);
+    reqs[2].flush(mockHabitsManifest);
+  });
+
+  it('should handle manifest load failure gracefully by filtering them out', () => {
+    service.loadServices().subscribe((loaded) => {
+      expect(loaded.length).toBe(1);
+      expect(loaded[0].name).toBe('passwords');
+    });
+
+    const reqs = [
+      httpMock.expectOne('/cloud-service.json'),
+      httpMock.expectOne('/password-manager-service.json'),
+      httpMock.expectOne('/habits-service.json'),
+    ];
+
+    reqs[0].flush('Not Found', { status: 404, statusText: 'Not Found' });
+    reqs[1].flush({
+      name: 'passwords',
+      displayName: 'Password Manager',
+      icon: 'pi-key',
+      route: '/passwords',
+      baseUrl: 'http://localhost:8091',
+      healthEndpoint: 'http://localhost:8091/api/health',
+    });
+    reqs[2].flush('Server Error', {
+      status: 500,
+      statusText: 'Internal Error',
+    });
+  });
+
+  it('should update availability states during health checks', () => {
+    const services: ServiceManifest[] = [
+      {
+        name: 'cloud',
+        displayName: 'Cloud',
+        icon: 'pi-cloud',
+        route: '/cloud',
+        baseUrl: 'http://localhost:8090',
+        apiUrl: 'http://localhost:8090/api',
+        healthEndpoint: 'http://localhost:8090/api/health',
+      },
+      {
+        name: 'passwords',
+        displayName: 'Password Manager',
+        icon: 'pi-key',
+        route: '/passwords',
+        baseUrl: 'http://localhost:8091',
+        apiUrl: 'http://localhost:8091/api',
+        healthEndpoint: 'http://localhost:8091/api/health',
+      },
+    ];
+
+    (service as any).services = services;
+
+    service.checkServicesHealth().subscribe((checked) => {
+      expect(checked[0].isAvailable).toBeTrue();
+      expect(checked[1].isAvailable).toBeFalse();
+    });
+
+    const reqCloud = httpMock.expectOne('http://localhost:8090/api/health');
+    const reqPM = httpMock.expectOne('http://localhost:8091/api/health');
+
+    reqCloud.flush({ status: 'UP' });
+    reqPM.flush('Service Unavailable', {
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+  });
+});

--- a/frontend/src/app/services/service-registry.service.spec.ts
+++ b/frontend/src/app/services/service-registry.service.spec.ts
@@ -29,15 +29,15 @@ describe('ServiceRegistryService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should load service manifests dynamically', () => {
+  it('should load service manifests dynamically and resolve templated host URLs', () => {
     const mockCloudManifest: ServiceManifest = {
       name: 'cloud',
       displayName: 'Cloud',
       icon: 'pi-cloud',
       route: '/cloud',
-      baseUrl: 'http://localhost:8090',
-      apiUrl: 'http://localhost:8090/api',
-      healthEndpoint: 'http://localhost:8090/api/health',
+      baseUrl: 'http://{host}:8090',
+      apiUrl: 'http://{host}:8090/api',
+      healthEndpoint: 'http://{host}:8090/api/health',
     };
 
     const mockPMManifest: ServiceManifest = {
@@ -45,19 +45,19 @@ describe('ServiceRegistryService', () => {
       displayName: 'Password Manager',
       icon: 'pi-key',
       route: '/passwords',
-      baseUrl: 'http://localhost:8091',
-      apiUrl: 'http://localhost:8091/api',
-      healthEndpoint: 'http://localhost:8091/api/health',
+      baseUrl: 'http://{host}:8091',
+      apiUrl: 'http://{host}:8091/api',
+      healthEndpoint: 'http://{host}:8091/api/health',
     };
 
     const mockHabitsManifest: ServiceManifest = {
       name: 'habits',
       displayName: 'Habits',
       icon: 'pi-calendar-plus',
-      route: '/habits',
-      baseUrl: 'http://localhost:8092',
-      apiUrl: 'http://localhost:8092/api',
-      healthEndpoint: 'http://localhost:8092/api/health',
+      route: 'http://{host}:8092',
+      baseUrl: 'http://{host}:8092',
+      apiUrl: 'http://{host}:8092/api',
+      healthEndpoint: 'http://{host}:8092/api/health',
     };
 
     service.loadServices().subscribe((loaded) => {
@@ -65,6 +65,7 @@ describe('ServiceRegistryService', () => {
       expect(loaded[0].name).toBe('cloud');
       expect(loaded[1].name).toBe('passwords');
       expect(loaded[2].name).toBe('habits');
+      expect(loaded[0].baseUrl).toContain(window.location.hostname);
     });
 
     const reqs = [
@@ -78,7 +79,7 @@ describe('ServiceRegistryService', () => {
     reqs[2].flush(mockHabitsManifest);
   });
 
-  it('should handle manifest load failure gracefully by filtering them out', () => {
+  it('should handle manifest load failure gracefully by filtering invalid/failed manifests', () => {
     service.loadServices().subscribe((loaded) => {
       expect(loaded.length).toBe(1);
       expect(loaded[0].name).toBe('passwords');
@@ -97,6 +98,7 @@ describe('ServiceRegistryService', () => {
       icon: 'pi-key',
       route: '/passwords',
       baseUrl: 'http://localhost:8091',
+      apiUrl: 'http://localhost:8091/api',
       healthEndpoint: 'http://localhost:8091/api/health',
     });
     reqs[2].flush('Server Error', {
@@ -106,36 +108,39 @@ describe('ServiceRegistryService', () => {
   });
 
   it('should update availability states during health checks', () => {
+    const cloudHealthUrl = service.resolveUrl('http://{host}:8090/api/health');
+    const pmHealthUrl = service.resolveUrl('http://{host}:8091/api/health');
+
     const services: ServiceManifest[] = [
       {
         name: 'cloud',
         displayName: 'Cloud',
         icon: 'pi-cloud',
         route: '/cloud',
-        baseUrl: 'http://localhost:8090',
-        apiUrl: 'http://localhost:8090/api',
-        healthEndpoint: 'http://localhost:8090/api/health',
+        baseUrl: service.resolveUrl('http://{host}:8090'),
+        apiUrl: service.resolveUrl('http://{host}:8090/api'),
+        healthEndpoint: cloudHealthUrl,
       },
       {
         name: 'passwords',
         displayName: 'Password Manager',
         icon: 'pi-key',
         route: '/passwords',
-        baseUrl: 'http://localhost:8091',
-        apiUrl: 'http://localhost:8091/api',
-        healthEndpoint: 'http://localhost:8091/api/health',
+        baseUrl: service.resolveUrl('http://{host}:8091'),
+        apiUrl: service.resolveUrl('http://{host}:8091/api'),
+        healthEndpoint: pmHealthUrl,
       },
     ];
 
-    (service as any).services = services;
+    (service as any).servicesSubject.next(services);
 
     service.checkServicesHealth().subscribe((checked) => {
       expect(checked[0].isAvailable).toBeTrue();
       expect(checked[1].isAvailable).toBeFalse();
     });
 
-    const reqCloud = httpMock.expectOne('http://localhost:8090/api/health');
-    const reqPM = httpMock.expectOne('http://localhost:8091/api/health');
+    const reqCloud = httpMock.expectOne(cloudHealthUrl);
+    const reqPM = httpMock.expectOne(pmHealthUrl);
 
     reqCloud.flush({ status: 'UP' });
     reqPM.flush('Service Unavailable', {

--- a/frontend/src/app/services/service-registry.service.ts
+++ b/frontend/src/app/services/service-registry.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, forkJoin, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+export interface ServiceManifest {
+  name: string;
+  displayName: string;
+  icon: string;
+  route: string;
+  baseUrl: string;
+  apiUrl: string;
+  healthEndpoint: string;
+  requiredScopes?: string[];
+  tokenForwarding?: {
+    enabled: boolean;
+    type?: 'header' | 'cookie' | 'query';
+    name?: string;
+  };
+  isAvailable?: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ServiceRegistryService {
+  private services: ServiceManifest[] = [];
+  private isLoaded = false;
+
+  constructor(private http: HttpClient) {}
+
+  loadServices(): Observable<ServiceManifest[]> {
+    const manifests = [
+      '/cloud-service.json',
+      '/password-manager-service.json',
+      '/habits-service.json',
+    ];
+
+    const requests = manifests.map((url) =>
+      this.http.get<ServiceManifest>(url).pipe(
+        catchError((err) => {
+          console.warn(`Failed to load service manifest from ${url}`, err);
+          return of(null);
+        }),
+      ),
+    );
+
+    return forkJoin(requests).pipe(
+      map((results) => {
+        const loadedServices: ServiceManifest[] = [];
+        for (const res of results) {
+          if (res && this.isValidManifest(res)) {
+            loadedServices.push(res);
+          }
+        }
+        this.services = loadedServices;
+        this.isLoaded = true;
+        return this.services;
+      }),
+    );
+  }
+
+  checkServicesHealth(): Observable<ServiceManifest[]> {
+    if (this.services.length === 0) {
+      return of([]);
+    }
+
+    const checks = this.services.map((service) =>
+      this.http.get(service.healthEndpoint).pipe(
+        map(() => {
+          service.isAvailable = true;
+          return service;
+        }),
+        catchError((err) => {
+          console.warn(`Service ${service.name} is unhealthy`, err);
+          service.isAvailable = false;
+          return of(service);
+        }),
+      ),
+    );
+
+    return forkJoin(checks).pipe(
+      map(() => {
+        return this.services;
+      }),
+    );
+  }
+
+  getServices(): ServiceManifest[] {
+    return this.services;
+  }
+
+  getServiceByName(name: string): ServiceManifest | undefined {
+    return this.services.find((s) => s.name === name);
+  }
+
+  private isValidManifest(manifest: unknown): boolean {
+    if (!manifest || typeof manifest !== 'object') {
+      return false;
+    }
+    const candidate = manifest as Record<string, unknown>;
+    return (
+      typeof candidate['name'] === 'string' &&
+      typeof candidate['displayName'] === 'string' &&
+      typeof candidate['icon'] === 'string' &&
+      typeof candidate['route'] === 'string' &&
+      typeof candidate['baseUrl'] === 'string' &&
+      typeof candidate['healthEndpoint'] === 'string'
+    );
+  }
+}

--- a/frontend/src/app/services/service-registry.service.ts
+++ b/frontend/src/app/services/service-registry.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable, forkJoin, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { HttpClient, HttpBackend } from '@angular/common/http';
+import { Observable, BehaviorSubject, forkJoin, of } from 'rxjs';
+import { catchError, map, timeout } from 'rxjs/operators';
 
 export interface ServiceManifest {
   name: string;
@@ -24,10 +24,41 @@ export interface ServiceManifest {
   providedIn: 'root',
 })
 export class ServiceRegistryService {
-  private services: ServiceManifest[] = [];
-  private isLoaded = false;
+  private servicesSubject = new BehaviorSubject<ServiceManifest[]>([]);
+  public services$ = this.servicesSubject.asObservable();
 
-  constructor(private http: HttpClient) {}
+  private isLoaded = false;
+  private rawHttpClient: HttpClient;
+
+  constructor(
+    private http: HttpClient,
+    handler: HttpBackend,
+  ) {
+    // Uses un-intercepted HttpClient to bypass tokenInterceptor and error handling banners during health checks
+    this.rawHttpClient = new HttpClient(handler);
+  }
+
+  resolveUrl(url: string): string {
+    if (!url) return '';
+    if (url.startsWith('/')) {
+      if (typeof window !== 'undefined' && window.location?.origin) {
+        return `${window.location.origin}${url}`;
+      }
+      return url;
+    }
+    if (typeof window !== 'undefined' && window.location?.hostname) {
+      const currentHost = window.location.hostname;
+      const currentProtocol = window.location.protocol;
+      let resolved = url
+        .replace('{host}', currentHost)
+        .replace('localhost', currentHost);
+      if (currentProtocol === 'https:' && resolved.startsWith('http:')) {
+        resolved = resolved.replace('http:', 'https:');
+      }
+      return resolved;
+    }
+    return url;
+  }
 
   loadServices(): Observable<ServiceManifest[]> {
     const manifests = [
@@ -37,7 +68,8 @@ export class ServiceRegistryService {
     ];
 
     const requests = manifests.map((url) =>
-      this.http.get<ServiceManifest>(url).pipe(
+      this.rawHttpClient.get<ServiceManifest>(url).pipe(
+        timeout(3000),
         catchError((err) => {
           console.warn(`Failed to load service manifest from ${url}`, err);
           return of(null);
@@ -50,23 +82,32 @@ export class ServiceRegistryService {
         const loadedServices: ServiceManifest[] = [];
         for (const res of results) {
           if (res && this.isValidManifest(res)) {
-            loadedServices.push(res);
+            const resolved: ServiceManifest = {
+              ...res,
+              baseUrl: this.resolveUrl(res.baseUrl),
+              apiUrl: this.resolveUrl(res.apiUrl),
+              healthEndpoint: this.resolveUrl(res.healthEndpoint),
+              route: this.resolveUrl(res.route),
+            };
+            loadedServices.push(resolved);
           }
         }
-        this.services = loadedServices;
+        this.servicesSubject.next(loadedServices);
         this.isLoaded = true;
-        return this.services;
+        return loadedServices;
       }),
     );
   }
 
   checkServicesHealth(): Observable<ServiceManifest[]> {
-    if (this.services.length === 0) {
+    const currentServices = this.servicesSubject.getValue();
+    if (currentServices.length === 0) {
       return of([]);
     }
 
-    const checks = this.services.map((service) =>
-      this.http.get(service.healthEndpoint).pipe(
+    const checks = currentServices.map((service) =>
+      this.rawHttpClient.get(service.healthEndpoint).pipe(
+        timeout(3000),
         map(() => {
           service.isAvailable = true;
           return service;
@@ -81,17 +122,18 @@ export class ServiceRegistryService {
 
     return forkJoin(checks).pipe(
       map(() => {
-        return this.services;
+        this.servicesSubject.next([...currentServices]);
+        return currentServices;
       }),
     );
   }
 
   getServices(): ServiceManifest[] {
-    return this.services;
+    return this.servicesSubject.getValue();
   }
 
   getServiceByName(name: string): ServiceManifest | undefined {
-    return this.services.find((s) => s.name === name);
+    return this.servicesSubject.getValue().find((s) => s.name === name);
   }
 
   private isValidManifest(manifest: unknown): boolean {
@@ -105,6 +147,7 @@ export class ServiceRegistryService {
       typeof candidate['icon'] === 'string' &&
       typeof candidate['route'] === 'string' &&
       typeof candidate['baseUrl'] === 'string' &&
+      typeof candidate['apiUrl'] === 'string' &&
       typeof candidate['healthEndpoint'] === 'string'
     );
   }


### PR DESCRIPTION
## Problem
Vault Web previously relied on a hardcoded list of services (Cloud, Password Manager) in its frontend configuration. Adding or modifying a service required editing Vault Web itself, making the portal and actual deployment prone to configuration drift.

## Solution
Introduced a dynamic service registry manifest system:

1. **Manifest Schema Definition**: Documented a standard JSON schema (`vault-service.json`) in [docs/service-manifest-schema.md](file:///d:/OpenSource/valulWeb/vault-web/docs/service-manifest-schema.md) specifying how each module describes itself (display details, route, health endpoints, required scopes, token forwarding).
2. **Mock Manifests shipped**: Shipped conformant manifests for `cloud`, `passwords`, and `habits` in the web root.
3. **Registry Startup & Health Verification**: Added `ServiceRegistryService` triggered via Angular `APP_INITIALIZER` to dynamically load manifests at boot and perform automated health checks on each service's health endpoint.
4. **Graceful UI Degradation**: Replaced hardcoded navigation links in the navbar (both desktop and mobile) with dynamically rendered items. Unreachable or missing services (such as Habits) degrade gracefully, displaying as disabled/greyed-out in the menu with an "offline" badge and descriptive tooltip.

## Verification Details
* Created unit tests in `service-registry.service.spec.ts` to assert manifest parsing, fallback handling, and health check integration.
* Verified that all unit tests pass successfully (`TOTAL: 21 SUCCESS`).
* Validated that Prettier formatting and ESLint are 100% clean (0 errors/warnings).