### PR TITLE
fix-click-chat-messege

### DIFF
--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
@@ -144,7 +144,10 @@
               [alt]="msg.stickerLabel || msg.content"
               loading="lazy"
             />
-            <div *ngSwitchDefault>{{ msg.content }}</div>
+            <div
+              *ngSwitchDefault
+              [innerHTML]="formatMessage(msg.content)"
+            ></div>
           </ng-container>
           <div class="message-time text-[10px] self-end mt-1 opacity-70">
             {{ msg.timestamp | date: "shortTime" }}

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.scss
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.scss
@@ -377,3 +377,15 @@ button {
     padding-inline: 0.8rem !important;
   }
 }
+
+/* ── Clickable links inside chat messages (inserted via innerHTML) ── */
+:host ::ng-deep .chat-bubble a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  word-break: break-all;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.spec.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.spec.ts
@@ -1,3 +1,5 @@
+/// <reference types="jasmine" />
+
 import {
   ComponentFixture,
   TestBed,
@@ -144,4 +146,160 @@ describe('PrivateChatDialogComponent typing indicators', () => {
     expect(component.typingIndicatorLabel).toBe('');
     discardPeriodicTasks();
   }));
+});
+
+describe('PrivateChatDialogComponent formatMessage', () => {
+  let fixture: ComponentFixture<PrivateChatDialogComponent>;
+  let component: PrivateChatDialogComponent;
+
+  beforeEach(async () => {
+    const typingEvents = new Subject<TypingIndicatorDto>();
+    const wsService = jasmine.createSpyObj<WebSocketService>(
+      'WebSocketService',
+      [
+        'subscribeToPrivateMessages',
+        'subscribeToTypingIndicators',
+        'sendTypingIndicator',
+        'ensureConnected',
+        'sendPrivateMessage',
+        'sendGroupMessage',
+        'subscribeToGroupMessages',
+      ],
+    );
+    wsService.subscribeToPrivateMessages.and.returnValue(of<ChatMessageDto>());
+    wsService.subscribeToGroupMessages.and.returnValue(of<ChatMessageDto>());
+    wsService.subscribeToTypingIndicators.and.returnValue(
+      typingEvents.asObservable(),
+    );
+    wsService.sendTypingIndicator.and.returnValue(true);
+    wsService.ensureConnected.and.resolveTo(true);
+    wsService.sendPrivateMessage.and.returnValue(true);
+    wsService.sendGroupMessage.and.returnValue(true);
+
+    const chatService = jasmine.createSpyObj<PrivateChatService>(
+      'PrivateChatService',
+      ['getMessages', 'getDevices'],
+    );
+    chatService.getMessages.and.returnValue(of([]));
+    chatService.getDevices.and.returnValue(of<DeviceDto[]>([]));
+
+    const groupChatService = jasmine.createSpyObj<GroupChatService>(
+      'GroupChatService',
+      ['getMessages', 'getDevices'],
+    );
+    groupChatService.getMessages.and.returnValue(of([]));
+    groupChatService.getDevices.and.returnValue(of<DeviceDto[]>([]));
+
+    const e2eeService = jasmine.createSpyObj<E2eeService>('E2eeService', [
+      'ensureDeviceRegistered',
+      'encryptForDevices',
+      'decryptPayload',
+    ]);
+    e2eeService.ensureDeviceRegistered.and.resolveTo();
+
+    const toast = jasmine.createSpyObj<UiToastService>('UiToastService', [
+      'error',
+      'warn',
+    ]);
+
+    const groupService = jasmine.createSpyObj<GroupService>('GroupService', [
+      'getGroupDetails',
+    ]);
+    const userService = jasmine.createSpyObj<UserService>('UserService', [
+      'getProfilePictureUrl',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [PrivateChatDialogComponent],
+      providers: [
+        { provide: WebSocketService, useValue: wsService },
+        { provide: PrivateChatService, useValue: chatService },
+        { provide: GroupChatService, useValue: groupChatService },
+        { provide: E2eeService, useValue: e2eeService },
+        { provide: UiToastService, useValue: toast },
+        { provide: GroupService, useValue: groupService },
+        { provide: UserService, useValue: userService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PrivateChatDialogComponent);
+    component = fixture.componentInstance;
+    component.username = 'bob';
+    component.currentUsername = 'alice';
+    component.privateChatId = 10;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  /** Helper: extract the raw HTML string from SafeHtml. */
+  function toHtml(safeHtml: unknown): string {
+    // SafeHtml wraps the value; coerce to string via a temp element
+    const div = document.createElement('div');
+    div.innerHTML =
+      (safeHtml as any)?.changingThisBreaksApplicationSecurity ??
+      String(safeHtml);
+    return div.innerHTML;
+  }
+
+  it('returns empty string for undefined input', () => {
+    expect(component.formatMessage(undefined) as string).toBe('');
+  });
+
+  it('returns empty string for empty string input', () => {
+    expect(component.formatMessage('') as string).toBe('');
+  });
+
+  it('renders plain text without any link markup', () => {
+    const html = toHtml(component.formatMessage('hello world'));
+    expect(html).not.toContain('<a');
+    expect(html).toContain('hello world');
+  });
+
+  it('converts a single URL into a clickable link', () => {
+    const html = toHtml(component.formatMessage('https://example.com'));
+    expect(html).toContain('<a');
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it('keeps surrounding text as plain text', () => {
+    const html = toHtml(
+      component.formatMessage('visit https://example.com now'),
+    );
+    expect(html).toContain('visit ');
+    expect(html).toContain(' now');
+    expect(html).toContain('href="https://example.com"');
+  });
+
+  it('handles multiple URLs in one message', () => {
+    const html = toHtml(
+      component.formatMessage('see https://a.com and http://b.com'),
+    );
+    const anchors = html.match(/<a /g);
+    expect(anchors?.length).toBe(2);
+  });
+
+  it('strips trailing punctuation from URLs', () => {
+    const html = toHtml(component.formatMessage('go to https://example.com.'));
+    expect(html).toContain('href="https://example.com"');
+    // The trailing period should be outside the anchor
+    expect(html).not.toContain('href="https://example.com."');
+  });
+
+  it('escapes HTML entities in plain text to prevent XSS', () => {
+    const html = toHtml(
+      component.formatMessage('<script>alert("xss")</script>'),
+    );
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('does not linkify javascript: scheme URLs', () => {
+    const html = toHtml(component.formatMessage('javascript:alert(1)'));
+    expect(html).not.toContain('<a');
+  });
 });

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -32,6 +32,8 @@ import {
   ChatSticker,
   findChatSticker,
 } from './chat-reactions';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import DOMPurify from 'dompurify';
 
 interface ChatMessageView {
   kind: 'text' | 'sticker';
@@ -94,6 +96,8 @@ export class PrivateChatDialogComponent
   @Output() closeChat = new EventEmitter<void>();
 
   messages: ChatMessageView[] = [];
+  /** Rendered messages, keyed by their text; see formatMessage. */
+  private readonly formattedMessages = new Map<string, SafeHtml>();
   newMessage = '';
   private devices: DeviceDto[] = [];
   private lastDevicesRefreshAt = 0;
@@ -141,6 +145,7 @@ export class PrivateChatDialogComponent
     private toast: UiToastService,
     private groupService: GroupService,
     private userService: UserService,
+    private sanitizer: DomSanitizer,
   ) {}
 
   ngOnInit(): void {
@@ -324,6 +329,7 @@ export class PrivateChatDialogComponent
             decryptedMessages: successfulMessages.length,
           });
         }
+        this.formattedMessages.clear();
         this.messages = successfulMessages;
         this.applySearch();
         this.shouldScroll = true;
@@ -741,6 +747,71 @@ export class PrivateChatDialogComponent
       stickerLabel: null,
       clientTimestamp: null,
     };
+  }
+
+  private escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  /**
+   * Rendered form of a message, with http/https URLs turned into links. The
+   * template binds to this, so the result is cached per message text: otherwise
+   * every change detection cycle re-escapes and re-sanitises every message on
+   * screen and hands the binding a fresh object, repainting the whole log.
+   */
+  formatMessage(content?: string): SafeHtml {
+    if (!content) {
+      return '';
+    }
+    const cached = this.formattedMessages.get(content);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const formatted = this.linkifyMessage(content);
+    this.formattedMessages.set(content, formatted);
+    return formatted;
+  }
+
+  private linkifyMessage(content: string): SafeHtml {
+    // Match http/https URLs, then strip common trailing punctuation
+    // that is usually not part of the URL (e.g. periods at end of sentences).
+    const urlRegex = /(https?:\/\/[^\s]+)/g;
+
+    let html = '';
+    let lastIndex = 0;
+
+    for (const match of content.matchAll(urlRegex)) {
+      const originalUrl = match[0];
+      const index = match.index ?? 0;
+
+      // Strip trailing punctuation that is almost never part of a URL
+      const url = originalUrl.replace(/[.,;:!?)]+$/, '');
+      const trailing = originalUrl.slice(url.length);
+
+      // Append escaped text before this URL
+      html += this.escapeHtml(content.substring(lastIndex, index));
+
+      // Build the anchor — escape the URL in both href and display text
+      const safeUrl = this.escapeHtml(url);
+      html += `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeUrl}</a>${this.escapeHtml(trailing)}`;
+
+      // Advance past the original match length
+      lastIndex = index + originalUrl.length;
+    }
+
+    html += this.escapeHtml(content.substring(lastIndex));
+
+    // DOMPurify strips target by default — allow it so links open in a new tab
+    const cleanHtml = DOMPurify.sanitize(html, {
+      ADD_ATTR: ['target'],
+    });
+
+    return this.sanitizer.bypassSecurityTrustHtml(cleanHtml);
   }
 
   private parseClientTimestamp(timestamp: string | undefined): string | null {


### PR DESCRIPTION
## Summary

Implemented support for clickable URLs in chat messages.

- Detects only `http://` and `https://` URLs in decrypted chat messages.
- Converts detected URLs into clickable links.
- Escapes all non-URL text before rendering to prevent HTML injection.
- Opens links in a new tab using `target="_blank"`.
- Adds `rel="noopener noreferrer"` for improved security.
- Sanitizes the generated HTML before binding it to the template.
- Keeps all non-URL message content as plain text.

## Linked issue

Closes #302

## How to test

1. Start the frontend.
2. Open a private chat.
3. Send the following messages:
   - `Hello World`
   - `https://google.com`
   - `Visit https://github.com/Vault-Web`
   - `https://google.com https://openai.com`
   - `ftp://example.com`
   - `<script>alert(1)</script>`
4. Verify:
   - Only `http://` and `https://` URLs are clickable.
   - Links open in a new tab.
   - All other text remains plain text.
   - HTML/script tags are displayed as text and are not executed.

## Notes / Risk

- The change is limited to plain URL detection as described in the issue.
- Markdown and arbitrary HTML rendering are intentionally not supported to minimize the attack surface.
- The generated HTML is sanitized before rendering for additional protection against XSS.