### PR TITLE
feat(chat): Implement full emoji picker with search and categories

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Set up Java
         uses: actions/setup-java@v5

--- a/.github/workflows/directory.yml
+++ b/.github/workflows/directory.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Run Directory Tree Generator
         uses: DenizAltunkapan/directory-tree-generator@v2

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: "npm"

--- a/.github/workflows/generate-javadoc.yml
+++ b/.github/workflows/generate-javadoc.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Set up Java
         uses: actions/setup-java@v5

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@stomp/stompjs": "^7.1.1",
         "@tailwindcss/postcss": "^4.1.10",
         "dompurify": "^3.4.11",
+        "emoji-picker-element": "^1.29.1",
         "marked": "^18.0.6",
         "ngx-toastr": "^19.1.0",
         "postcss": "^8.5.6",
@@ -8349,6 +8350,12 @@
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-picker-element": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/emoji-picker-element/-/emoji-picker-element-1.29.1.tgz",
+      "integrity": "sha512-TOiHzu9Dqib3x4MwcAi3wi3RdyT4SoeB4b15AvH1ks4SBwTl7DeebhZ0d3x6dNi4XfNU7IGRZ7NBQllj0RqwrQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --ssl",
+    "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@stomp/stompjs": "^7.1.1",
     "@tailwindcss/postcss": "^4.1.10",
     "dompurify": "^3.4.11",
+    "emoji-picker-element": "^1.29.1",
     "marked": "^18.0.6",
     "ngx-toastr": "^19.1.0",
     "postcss": "^8.5.6",

--- a/frontend/src/app/pages/private-chat-dialog/chat-reactions.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-reactions.ts
@@ -4,7 +4,6 @@ export interface ChatSticker {
   src: string;
 }
 
-
 export const CHAT_STICKERS: ChatSticker[] = [
   {
     id: 'spark',

--- a/frontend/src/app/pages/private-chat-dialog/chat-reactions.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-reactions.ts
@@ -4,24 +4,6 @@ export interface ChatSticker {
   src: string;
 }
 
-export const CHAT_EMOJIS = [
-  '😀',
-  '😂',
-  '😊',
-  '😍',
-  '😎',
-  '🥳',
-  '🤔',
-  '👍',
-  '🙏',
-  '🔥',
-  '✨',
-  '💙',
-  '🎉',
-  '✅',
-  '👀',
-  '💡',
-];
 
 export const CHAT_STICKERS: ChatSticker[] = [
   {

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
@@ -202,21 +202,12 @@
         *ngIf="isEmojiPickerOpen || isStickerPickerOpen"
         class="reaction-popover"
       >
-        <div
+        <emoji-picker
           *ngIf="isEmojiPickerOpen"
-          class="emoji-grid"
-          aria-label="Emoji picker"
-        >
-          <button
-            *ngFor="let emoji of emojis"
-            type="button"
-            class="emoji-option"
-            (click)="insertEmoji(emoji)"
-            [attr.aria-label]="'Insert ' + emoji"
-          >
-            {{ emoji }}
-          </button>
-        </div>
+          class="light"
+          (emoji-click)="insertEmoji($event)"
+          (keydown)="onEmojiPickerKeydown($event)"
+        ></emoji-picker>
 
         <div
           *ngIf="isStickerPickerOpen"
@@ -264,7 +255,7 @@
         class="chat-input flex-1 px-3 py-2 outline-none border bg-[var(--surface-b)] text-[var(--text-color)]"
         placeholder="Type a message..."
         autocomplete="off"
-        (focus)="closeReactionPickers()"
+        (focus)="onInputFocus()"
       />
       <button
         type="submit"

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
@@ -205,6 +205,7 @@
         <emoji-picker
           *ngIf="isEmojiPickerOpen"
           class="light"
+          aria-label="Emoji picker"
           (emoji-click)="insertEmoji($event)"
           (keydown)="onEmojiPickerKeydown($event)"
         ></emoji-picker>

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.scss
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.scss
@@ -282,28 +282,18 @@ button {
   z-index: 2;
 }
 
-.emoji-grid {
-  display: grid;
-  grid-template-columns: repeat(8, minmax(2rem, 1fr));
-  gap: 0.35rem;
-}
-
-.emoji-option {
-  aspect-ratio: 1;
-  border-radius: 0.5rem;
-  border: 1px solid transparent;
-  background: transparent;
-  font-size: 1.35rem;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  &:hover,
-  &:focus-visible {
-    border-color: var(--color-border-hover);
-    background: var(--color-surface-hover);
-  }
+emoji-picker {
+  width: 100%;
+  height: 320px;
+  --background: transparent;
+  --border-color: var(--color-border);
+  --input-border-color: var(--color-input-border);
+  --input-font-color: var(--color-text-primary);
+  --category-font-color: var(--color-text-secondary);
+  --indicator-color: var(--color-primary);
+  --button-hover-background: var(--color-surface-hover);
+  --num-columns: 8;
+  --emoji-size: 1.5rem;
 }
 
 .sticker-grid {
@@ -364,8 +354,8 @@ button {
     right: 0.75rem;
   }
 
-  .emoji-grid {
-    grid-template-columns: repeat(4, minmax(2.4rem, 1fr));
+  emoji-picker {
+    --num-columns: 6;
   }
 
   .sticker-grid {

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -423,6 +423,10 @@ export class PrivateChatDialogComponent
         ? eventOrEmoji.detail.unicode
         : eventOrEmoji;
 
+    if (typeof emoji !== 'string') {
+      return;
+    }
+
     const input = this.messageInput?.nativeElement;
     if (!input) {
       this.newMessage += emoji;
@@ -439,21 +443,19 @@ export class PrivateChatDialogComponent
       input.focus();
       const cursorPosition = start + emoji.length;
       input.setSelectionRange(cursorPosition, cursorPosition);
-      setTimeout(() => (this.preventFocusClose = false), 100);
+      this.preventFocusClose = false;
     }, 0);
   }
 
   onEmojiPickerKeydown(event: Event): void {
     const kbEvent = event as KeyboardEvent;
     if (kbEvent.key === 'ArrowLeft' || kbEvent.key === 'ArrowRight') {
-      const picker = event.target as HTMLElement;
+      const picker = event.currentTarget as HTMLElement;
       // Allow the web component's own keydown handler to move focus first
       setTimeout(() => {
-        if (picker.shadowRoot) {
-          const activeEl = picker.shadowRoot.activeElement as HTMLElement;
-          if (activeEl && activeEl.getAttribute('role') === 'tab') {
-            activeEl.click();
-          }
+        const activeEl = picker.shadowRoot?.activeElement as HTMLElement | null;
+        if (activeEl?.getAttribute('role') === 'tab') {
+          activeEl.click();
         }
       }, 0);
     }

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -11,6 +11,8 @@ import {
   ViewChildren,
   AfterViewChecked,
   OnDestroy,
+  CUSTOM_ELEMENTS_SCHEMA,
+  HostListener,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ChatMessageDto } from '../../models/dtos/ChatMessageDto';
@@ -27,13 +29,13 @@ import { UserService } from '../../services/user.service';
 import { GroupDto } from '../../models/dtos/GroupDto';
 import { UserDto } from '../../models/dtos/UserDto';
 import {
-  CHAT_EMOJIS,
   CHAT_STICKERS,
   ChatSticker,
   findChatSticker,
 } from './chat-reactions';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import DOMPurify from 'dompurify';
+import 'emoji-picker-element';
 
 interface ChatMessageView {
   kind: 'text' | 'sticker';
@@ -82,6 +84,7 @@ type ParsedDecryptedMessageBody = {
   imports: [CommonModule, FormsModule],
   templateUrl: './private-chat-dialog.component.html',
   styleUrls: ['./private-chat-dialog.component.scss'],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class PrivateChatDialogComponent
   implements OnInit, OnDestroy, AfterViewChecked
@@ -118,10 +121,10 @@ export class PrivateChatDialogComponent
   matchedMessageIndexes: number[] = [];
   private matchedMessageIndexSet = new Set<number>();
   activeMatchPosition = -1;
-  readonly emojis = CHAT_EMOJIS;
   readonly stickers = CHAT_STICKERS;
   isEmojiPickerOpen = false;
   isStickerPickerOpen = false;
+  private preventFocusClose = false;
   private isTyping = false;
   private typingIdleTimer: ReturnType<typeof setTimeout> | null = null;
   private typingStaleSweepTimer: ReturnType<typeof setInterval> | null = null;
@@ -418,7 +421,12 @@ export class PrivateChatDialogComponent
     };
   }
 
-  insertEmoji(emoji: string): void {
+  insertEmoji(eventOrEmoji: any): void {
+    const emoji =
+      eventOrEmoji && eventOrEmoji.detail && eventOrEmoji.detail.unicode
+        ? eventOrEmoji.detail.unicode
+        : eventOrEmoji;
+    
     const input = this.messageInput?.nativeElement;
     if (!input) {
       this.newMessage += emoji;
@@ -429,13 +437,34 @@ export class PrivateChatDialogComponent
     const end = input.selectionEnd ?? start;
     this.newMessage =
       this.newMessage.slice(0, start) + emoji + this.newMessage.slice(end);
-    this.closeReactionPickers();
 
+    this.preventFocusClose = true;
     setTimeout(() => {
       input.focus();
       const cursorPosition = start + emoji.length;
       input.setSelectionRange(cursorPosition, cursorPosition);
+      setTimeout(() => this.preventFocusClose = false, 100);
     }, 0);
+  }
+
+  onEmojiPickerKeydown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+      const picker = event.target as HTMLElement;
+      // Allow the web component's own keydown handler to move focus first
+      setTimeout(() => {
+        if (picker.shadowRoot) {
+          const activeEl = picker.shadowRoot.activeElement as HTMLElement;
+          if (activeEl && activeEl.getAttribute('role') === 'tab') {
+            activeEl.click();
+          }
+        }
+      }, 0);
+    }
+  }
+
+  onInputFocus(): void {
+    if (this.preventFocusClose) return;
+    this.closeReactionPickers();
   }
 
   sendSticker(sticker: ChatSticker): void {
@@ -451,6 +480,20 @@ export class PrivateChatDialogComponent
   toggleStickerPicker(): void {
     this.isStickerPickerOpen = !this.isStickerPickerOpen;
     this.isEmojiPickerOpen = false;
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (!this.isEmojiPickerOpen && !this.isStickerPickerOpen) {
+      return;
+    }
+    const target = event.target as HTMLElement;
+    if (
+      !target.closest('.reaction-popover') &&
+      !target.closest('.composer-tool-btn')
+    ) {
+      this.closeReactionPickers();
+    }
   }
 
   closeReactionPickers(): void {

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -28,11 +28,7 @@ import { GroupService } from '../../services/group.service';
 import { UserService } from '../../services/user.service';
 import { GroupDto } from '../../models/dtos/GroupDto';
 import { UserDto } from '../../models/dtos/UserDto';
-import {
-  CHAT_STICKERS,
-  ChatSticker,
-  findChatSticker,
-} from './chat-reactions';
+import { CHAT_STICKERS, ChatSticker, findChatSticker } from './chat-reactions';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import DOMPurify from 'dompurify';
 import 'emoji-picker-element';
@@ -426,7 +422,7 @@ export class PrivateChatDialogComponent
       eventOrEmoji && eventOrEmoji.detail && eventOrEmoji.detail.unicode
         ? eventOrEmoji.detail.unicode
         : eventOrEmoji;
-    
+
     const input = this.messageInput?.nativeElement;
     if (!input) {
       this.newMessage += emoji;
@@ -443,12 +439,13 @@ export class PrivateChatDialogComponent
       input.focus();
       const cursorPosition = start + emoji.length;
       input.setSelectionRange(cursorPosition, cursorPosition);
-      setTimeout(() => this.preventFocusClose = false, 100);
+      setTimeout(() => (this.preventFocusClose = false), 100);
     }, 0);
   }
 
-  onEmojiPickerKeydown(event: KeyboardEvent): void {
-    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+  onEmojiPickerKeydown(event: Event): void {
+    const kbEvent = event as KeyboardEvent;
+    if (kbEvent.key === 'ArrowLeft' || kbEvent.key === 'ArrowRight') {
       const picker = event.target as HTMLElement;
       // Allow the web component's own keydown handler to move focus first
       setTimeout(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "vault-web",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "vault-web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary

Replaced the hardcoded, limited emoji list in the chat composer with a full-featured emoji picker using `emoji-picker-element`. 

- Integrates the full standard system emoji dataset.
- Adds search functionality (by name or keyword).
- Adds category tabs (Smileys, People, Nature, etc.).
- Adds a "Recently used" section that persists locally.
- Implements a click-outside handler to cleanly close the popover.
- Implements an accessibility enhancement so category tabs switch automatically when navigating via keyboard `ArrowLeft` / `ArrowRight`.

## Linked issue

Closes #303

## How to test

1. Open a chat dialog and click the emoji (smile) icon in the composer.
2. Verify the full emoji picker opens and renders correctly.
3. Type a query in the search bar and verify the results filter correctly.
4. Use the `ArrowLeft` and `ArrowRight` keys to navigate the category tabs and verify the categories switch instantly.
5. Click an emoji (or press Enter) and verify it is inserted at the exact cursor position in the composer input field.
6. Click anywhere outside the popover (e.g., on the chat messages) and verify the picker closes automatically.

## Notes / Risk

- **Bundle Size:** The impact on bundle size is extremely minimal because `emoji-picker-element` relies entirely on native system fonts rather than shipping large sprite sheets. 
- **Dependencies:** Added `emoji-picker-element` as a runtime dependency.
