### PR TITLE
fix(chat): derive private chat sender from authenticated security con…

### DIFF
--- a/backend/src/main/java/vaultWeb/controllers/PrivateChatController.java
+++ b/backend/src/main/java/vaultWeb/controllers/PrivateChatController.java
@@ -57,9 +57,9 @@ public class PrivateChatController {
       responseCode = "401",
       description = "Unauthorized request. You must provide an authentication token.")
   public PrivateChatDto getOrCreatePrivateChat(
-        @RequestParam String receiver, Authentication authentication) {
+    @RequestParam String receiver, Authentication authentication) {
     if (authentication == null) {
-        throw new UnauthorizedException("User not authenticated");
+    throw new UnauthorizedException("User not authenticated");
     }
     String sender = authentication.getName();
     PrivateChat chat = privateChatService.getOrCreatePrivateChat(sender, receiver);

--- a/backend/src/main/java/vaultWeb/controllers/PrivateChatController.java
+++ b/backend/src/main/java/vaultWeb/controllers/PrivateChatController.java
@@ -57,8 +57,13 @@ public class PrivateChatController {
       responseCode = "401",
       description = "Unauthorized request. You must provide an authentication token.")
   public PrivateChatDto getOrCreatePrivateChat(
-      @RequestParam String sender, @RequestParam String receiver) {
+        @RequestParam String receiver, Authentication authentication) {
+    if (authentication == null) {
+        throw new UnauthorizedException("User not authenticated");
+    }
+    String sender = authentication.getName();
     PrivateChat chat = privateChatService.getOrCreatePrivateChat(sender, receiver);
+
     return new PrivateChatDto(
         chat.getId(), chat.getUser1().getUsername(), chat.getUser2().getUsername());
   }

--- a/backend/src/main/java/vaultWeb/controllers/PrivateChatController.java
+++ b/backend/src/main/java/vaultWeb/controllers/PrivateChatController.java
@@ -57,9 +57,9 @@ public class PrivateChatController {
       responseCode = "401",
       description = "Unauthorized request. You must provide an authentication token.")
   public PrivateChatDto getOrCreatePrivateChat(
-    @RequestParam String receiver, Authentication authentication) {
+      @RequestParam String receiver, Authentication authentication) {
     if (authentication == null) {
-    throw new UnauthorizedException("User not authenticated");
+      throw new UnauthorizedException("User not authenticated");
     }
     String sender = authentication.getName();
     PrivateChat chat = privateChatService.getOrCreatePrivateChat(sender, receiver);

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -154,20 +154,18 @@ export class HomeComponent implements OnInit {
 
     this.selectedUsername = username;
 
-    this.privateChatService
-      .getOrCreatePrivateChat(username)
-      .subscribe({
-        next: (chat: PrivateChatDto) => {
-          this.privateChatId = chat.id;
-        },
-        error: () => {
-          console.error('Failed to get or create private chat');
-          this.toast.error(
-            'Chat unavailable',
-            'Could not open this chat right now.',
-          );
-        },
-      });
+    this.privateChatService.getOrCreatePrivateChat(username).subscribe({
+      next: (chat: PrivateChatDto) => {
+        this.privateChatId = chat.id;
+      },
+      error: () => {
+        console.error('Failed to get or create private chat');
+        this.toast.error(
+          'Chat unavailable',
+          'Could not open this chat right now.',
+        );
+      },
+    });
   }
 
   closeChat(): void {

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -155,7 +155,7 @@ export class HomeComponent implements OnInit {
     this.selectedUsername = username;
 
     this.privateChatService
-      .getOrCreatePrivateChat(this.currentUsername, username)
+      .getOrCreatePrivateChat(username)
       .subscribe({
         next: (chat: PrivateChatDto) => {
           this.privateChatId = chat.id;

--- a/frontend/src/app/services/private-chat.service.ts
+++ b/frontend/src/app/services/private-chat.service.ts
@@ -17,9 +17,7 @@ export class PrivateChatService {
 
   constructor(private http: HttpClient) {}
 
-  getOrCreatePrivateChat(
-    username2: string,
-  ): Observable<PrivateChatDto> {
+  getOrCreatePrivateChat(username2: string): Observable<PrivateChatDto> {
     return this.http.get<PrivateChatDto>(
       `${this.apiUrl}/private-chats/between?receiver=${encodeURIComponent(username2)}`,
     );

--- a/frontend/src/app/services/private-chat.service.ts
+++ b/frontend/src/app/services/private-chat.service.ts
@@ -18,11 +18,10 @@ export class PrivateChatService {
   constructor(private http: HttpClient) {}
 
   getOrCreatePrivateChat(
-    username1: string,
     username2: string,
   ): Observable<PrivateChatDto> {
     return this.http.get<PrivateChatDto>(
-      `${this.apiUrl}/private-chats/between?sender=${username1}&receiver=${username2}`,
+      `${this.apiUrl}/private-chats/between?receiver=${encodeURIComponent(username2)}`,
     );
   }
 


### PR DESCRIPTION
## Summary
Fixed the private chat impersonation issue by deriving the authenticated sender from the Spring Security context instead of trusting a request parameter. The endpoint now uses the current user from Authentication#getName() and only accepts the receiver from the request.

## Linked issue
Closes #314

## How to test
a. Authenticate as a user and call /api/private-chats/between?receiver=otherUser
b. Confirm the chat is created/retrieved for the authenticated user only
c. Try passing a different sender value in the request and verify it is ignored
d. Confirm the endpoint still works normally for valid authenticated requests

## Notes / Risk
a. Low risk: this is a controller-level authorization fix
b. Frontend callers should stop sending sender in the query string
c. No database migration or config change required