### PR TITLE
Fix duplicate message shown to sender in group and private chats (#298)

### DIFF
--- a/backend/src/main/java/vaultWeb/dtos/ChatMessageDto.java
+++ b/backend/src/main/java/vaultWeb/dtos/ChatMessageDto.java
@@ -21,4 +21,6 @@ public class ChatMessageDto {
   private String e2eePayload;
   private MessageType messageType;
   private PollResponseDto poll;
+
+  private String clientMessageId;
 }

--- a/backend/src/main/java/vaultWeb/models/ChatMessage.java
+++ b/backend/src/main/java/vaultWeb/models/ChatMessage.java
@@ -43,4 +43,7 @@ public class ChatMessage {
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "poll_id")
   private Poll poll;
+
+  @Column(name = "client_message_id", length = 36, nullable = true)
+  private String clientMessageId;
 }

--- a/backend/src/main/java/vaultWeb/services/ChatService.java
+++ b/backend/src/main/java/vaultWeb/services/ChatService.java
@@ -81,6 +81,7 @@ public class ChatService {
     ChatMessage message = new ChatMessage();
     message.setSender(sender);
     message.setMessageType(messageType);
+    message.setClientMessageId(dto.getClientMessageId());
 
     if (dto.getTimestamp() != null) {
       message.setTimestamp(Instant.parse(dto.getTimestamp()));
@@ -136,6 +137,8 @@ public class ChatService {
     dto.setSenderUsername(message.getSender().getUsername());
 
     dto.setSenderDeviceId(message.getSenderDeviceId());
+
+    dto.setClientMessageId(message.getClientMessageId());
 
     MessageType messageType =
         message.getMessageType() != null ? message.getMessageType() : MessageType.TEXT;

--- a/backend/src/test/java/vaultWeb/services/ChatServiceTest.java
+++ b/backend/src/test/java/vaultWeb/services/ChatServiceTest.java
@@ -196,6 +196,79 @@ class ChatServiceTest {
   }
 
   @Test
+  void shouldPersistClientMessageIdWhenSaving() {
+    User sender = createUser(1L, "user1");
+    Group group = createGroup(10L);
+    ChatMessageDto dto = new ChatMessageDto();
+    dto.setSenderId(1L);
+    dto.setGroupId(10L);
+    dto.setE2eePayload(VALID_E2EE_PAYLOAD);
+    dto.setSenderDeviceId(SENDER_DEVICE_ID);
+    dto.setClientMessageId("client-uuid-123");
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(sender));
+    when(groupRepository.findById(10L)).thenReturn(Optional.of(group));
+    when(chatMessageRepository.save(any(ChatMessage.class))).thenAnswer(i -> i.getArgument(0));
+
+    ChatMessage result = chatService.saveMessage(dto);
+
+    assertEquals("client-uuid-123", result.getClientMessageId());
+  }
+
+  @Test
+  void shouldAllowNullClientMessageId_forBackwardCompatibility() {
+    User sender = createUser(1L, "user1");
+    Group group = createGroup(10L);
+    ChatMessageDto dto = new ChatMessageDto();
+    dto.setSenderId(1L);
+    dto.setGroupId(10L);
+    dto.setE2eePayload(VALID_E2EE_PAYLOAD);
+    dto.setSenderDeviceId(SENDER_DEVICE_ID);
+    // clientMessageId intentionally left unset, simulating a pre-migration client
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(sender));
+    when(groupRepository.findById(10L)).thenReturn(Optional.of(group));
+    when(chatMessageRepository.save(any(ChatMessage.class))).thenAnswer(i -> i.getArgument(0));
+
+    ChatMessage result = chatService.saveMessage(dto);
+
+    assertNull(result.getClientMessageId());
+  }
+
+  @Test
+  void shouldEchoClientMessageIdInToDto() {
+    User sender = createUser(1L, "user1");
+    Group group = createGroup(10L);
+    ChatMessage message = new ChatMessage();
+    message.setSender(sender);
+    message.setGroup(group);
+    message.setTimestamp(java.time.Instant.parse("2026-03-26T10:15:30Z"));
+    message.setE2eePayload(VALID_E2EE_PAYLOAD);
+    message.setSenderDeviceId(SENDER_DEVICE_ID);
+    message.setClientMessageId("client-uuid-123");
+
+    ChatMessageDto dto = chatService.toDto(message);
+
+    assertEquals("client-uuid-123", dto.getClientMessageId());
+  }
+
+  @Test
+  void shouldReturnNullClientMessageId_forLegacyMessagesWithoutOne() {
+    User sender = createUser(1L, "user1");
+    Group group = createGroup(10L);
+    ChatMessage message = new ChatMessage();
+    message.setSender(sender);
+    message.setGroup(group);
+    message.setTimestamp(java.time.Instant.parse("2026-03-26T10:15:30Z"));
+    message.setE2eePayload(VALID_E2EE_PAYLOAD);
+    message.setSenderDeviceId(SENDER_DEVICE_ID);
+
+    ChatMessageDto dto = chatService.toDto(message);
+
+    assertNull(dto.getClientMessageId());
+  }
+
+  @Test
   void shouldFailSaveMessage_WhenGroupNotFound() {
     User sender = createUser(1L, "user1");
     ChatMessageDto dto = new ChatMessageDto();

--- a/frontend/src/app/models/dtos/ChatMessageDto.ts
+++ b/frontend/src/app/models/dtos/ChatMessageDto.ts
@@ -6,4 +6,5 @@ export interface ChatMessageDto {
   timestamp: string;
   senderDeviceId?: string;
   e2eePayload?: string;
+  clientMessageId?: string;
 }

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.spec.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.spec.ts
@@ -395,7 +395,9 @@ describe('PrivateChatDialogComponent duplicate message detection', () => {
     fixture.destroy();
   });
 
-  function baseMessage(overrides: Partial<ChatMessageDto> = {}): ChatMessageDto {
+  function baseMessage(
+    overrides: Partial<ChatMessageDto> = {},
+  ): ChatMessageDto {
     return {
       timestamp: '2026-08-19T10:00:00.000Z',
       senderUsername: 'alice',
@@ -406,7 +408,7 @@ describe('PrivateChatDialogComponent duplicate message detection', () => {
     };
   }
 
-describe('id-based matching (clientMessageId present)', () => {
+  describe('id-based matching (clientMessageId present)', () => {
     it('treats two messages with the same clientMessageId as duplicates', () => {
       (component as any).messages = [
         {
@@ -442,7 +444,7 @@ describe('id-based matching (clientMessageId present)', () => {
     });
   });
 
- describe('fallback matching (no clientMessageId — legacy/pre-migration messages)', () => {
+  describe('fallback matching (no clientMessageId — legacy/pre-migration messages)', () => {
     it('regression test for #298: treats group message echo as duplicate despite undefined vs null privateChatId', () => {
       (component as any).messages = [
         {
@@ -505,7 +507,9 @@ describe('id-based matching (clientMessageId present)', () => {
   it('end-to-end: sending a message then receiving its own echo does not duplicate it in the view', fakeAsync(() => {
     component.newMessage = 'hello there';
 
-    const e2eeService = TestBed.inject(E2eeService) as jasmine.SpyObj<E2eeService>;
+    const e2eeService = TestBed.inject(
+      E2eeService,
+    ) as jasmine.SpyObj<E2eeService>;
     e2eeService.encryptForDevices.and.resolveTo({
       senderDeviceId: 'device-1',
     } as any);

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.spec.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.spec.ts
@@ -303,3 +303,226 @@ describe('PrivateChatDialogComponent formatMessage', () => {
     expect(html).not.toContain('<a');
   });
 });
+
+describe('PrivateChatDialogComponent duplicate message detection', () => {
+  let fixture: ComponentFixture<PrivateChatDialogComponent>;
+  let component: PrivateChatDialogComponent;
+  let privateMessages: Subject<ChatMessageDto>;
+  let groupMessages: Subject<ChatMessageDto>;
+  let wsService: jasmine.SpyObj<WebSocketService>;
+
+  beforeEach(async () => {
+    privateMessages = new Subject<ChatMessageDto>();
+    groupMessages = new Subject<ChatMessageDto>();
+    wsService = jasmine.createSpyObj<WebSocketService>('WebSocketService', [
+      'subscribeToPrivateMessages',
+      'subscribeToTypingIndicators',
+      'sendTypingIndicator',
+      'ensureConnected',
+      'sendPrivateMessage',
+      'sendGroupMessage',
+      'subscribeToGroupMessages',
+    ]);
+    wsService.subscribeToPrivateMessages.and.returnValue(
+      privateMessages.asObservable(),
+    );
+    wsService.subscribeToGroupMessages.and.returnValue(
+      groupMessages.asObservable(),
+    );
+    wsService.subscribeToTypingIndicators.and.returnValue(
+      new Subject<TypingIndicatorDto>().asObservable(),
+    );
+    wsService.sendTypingIndicator.and.returnValue(true);
+    wsService.ensureConnected.and.resolveTo(true);
+    wsService.sendPrivateMessage.and.returnValue(true);
+    wsService.sendGroupMessage.and.returnValue(true);
+
+    const chatService = jasmine.createSpyObj<PrivateChatService>(
+      'PrivateChatService',
+      ['getMessages', 'getDevices'],
+    );
+    chatService.getMessages.and.returnValue(of([]));
+    chatService.getDevices.and.returnValue(of<DeviceDto[]>([]));
+
+    const groupChatService = jasmine.createSpyObj<GroupChatService>(
+      'GroupChatService',
+      ['getMessages', 'getDevices'],
+    );
+    groupChatService.getMessages.and.returnValue(of([]));
+    groupChatService.getDevices.and.returnValue(of<DeviceDto[]>([]));
+
+    const e2eeService = jasmine.createSpyObj<E2eeService>('E2eeService', [
+      'ensureDeviceRegistered',
+      'encryptForDevices',
+      'decryptPayload',
+    ]);
+    e2eeService.ensureDeviceRegistered.and.resolveTo();
+
+    const toast = jasmine.createSpyObj<UiToastService>('UiToastService', [
+      'error',
+      'warn',
+    ]);
+
+    const groupService = jasmine.createSpyObj<GroupService>('GroupService', [
+      'getGroupDetails',
+    ]);
+    const userService = jasmine.createSpyObj<UserService>('UserService', [
+      'getProfilePictureUrl',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [PrivateChatDialogComponent],
+      providers: [
+        { provide: WebSocketService, useValue: wsService },
+        { provide: PrivateChatService, useValue: chatService },
+        { provide: GroupChatService, useValue: groupChatService },
+        { provide: E2eeService, useValue: e2eeService },
+        { provide: UiToastService, useValue: toast },
+        { provide: GroupService, useValue: groupService },
+        { provide: UserService, useValue: userService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PrivateChatDialogComponent);
+    component = fixture.componentInstance;
+    component.username = 'bob';
+    component.currentUsername = 'alice';
+    component.privateChatId = 10;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  function baseMessage(overrides: Partial<ChatMessageDto> = {}): ChatMessageDto {
+    return {
+      timestamp: '2026-08-19T10:00:00.000Z',
+      senderUsername: 'alice',
+      privateChatId: 10,
+      groupId: null,
+      senderDeviceId: 'device-1',
+      ...overrides,
+    };
+  }
+
+describe('id-based matching (clientMessageId present)', () => {
+    it('treats two messages with the same clientMessageId as duplicates', () => {
+      (component as any).messages = [
+        {
+          senderUsername: 'alice',
+          privateChatId: 10,
+          groupId: undefined,
+          timestamp: '2026-08-19T10:00:00.000Z',
+          clientMessageId: 'abc-123',
+          content: 'hi',
+          kind: 'text',
+        },
+      ];
+
+      const incoming = baseMessage({ clientMessageId: 'abc-123' } as any);
+      expect((component as any).isDuplicateMessage(incoming)).toBe(true);
+    });
+
+    it('does not treat messages with different clientMessageIds as duplicates', () => {
+      (component as any).messages = [
+        {
+          senderUsername: 'alice',
+          privateChatId: 10,
+          groupId: undefined,
+          timestamp: '2026-08-19T10:00:00.000Z',
+          clientMessageId: 'abc-123',
+          content: 'hi',
+          kind: 'text',
+        },
+      ];
+
+      const incoming = baseMessage({ clientMessageId: 'xyz-999' } as any);
+      expect((component as any).isDuplicateMessage(incoming)).toBe(false);
+    });
+  });
+
+ describe('fallback matching (no clientMessageId — legacy/pre-migration messages)', () => {
+    it('regression test for #298: treats group message echo as duplicate despite undefined vs null privateChatId', () => {
+      (component as any).messages = [
+        {
+          senderUsername: 'alice',
+          groupId: 42,
+          privateChatId: undefined,
+          timestamp: '2026-08-19T10:00:00.000Z',
+          content: 'hi',
+          kind: 'text',
+        },
+      ];
+
+      const incoming = baseMessage({
+        privateChatId: null as any,
+        groupId: 42,
+      });
+
+      expect((component as any).isDuplicateMessage(incoming)).toBe(true);
+    });
+
+    it('regression test for #298: treats private chat echo as duplicate despite undefined vs null groupId', () => {
+      (component as any).messages = [
+        {
+          senderUsername: 'bob',
+          groupId: undefined,
+          privateChatId: 7,
+          timestamp: '2026-08-19T10:05:00.000Z',
+          content: 'yo',
+          kind: 'text',
+        },
+      ];
+
+      const incoming = baseMessage({
+        senderUsername: 'bob',
+        groupId: null as any,
+        privateChatId: 7,
+        timestamp: '2026-08-19T10:05:00.000Z',
+      });
+
+      expect((component as any).isDuplicateMessage(incoming)).toBe(true);
+    });
+
+    it('does not flag genuinely different messages (different sender) as duplicates', () => {
+      (component as any).messages = [
+        {
+          senderUsername: 'alice',
+          privateChatId: 10,
+          groupId: undefined,
+          timestamp: '2026-08-19T10:00:00.000Z',
+          content: 'hi',
+          kind: 'text',
+        },
+      ];
+
+      const incoming = baseMessage({ senderUsername: 'carol' });
+      expect((component as any).isDuplicateMessage(incoming)).toBe(false);
+    });
+  });
+
+  it('end-to-end: sending a message then receiving its own echo does not duplicate it in the view', fakeAsync(() => {
+    component.newMessage = 'hello there';
+
+    const e2eeService = TestBed.inject(E2eeService) as jasmine.SpyObj<E2eeService>;
+    e2eeService.encryptForDevices.and.resolveTo({
+      senderDeviceId: 'device-1',
+    } as any);
+    (component as any).devices = [{ deviceId: 'device-1' } as DeviceDto];
+
+    component.sendMessage();
+    tick();
+
+    expect(component.messages.length).toBe(1);
+    const sentMessage = wsService.sendPrivateMessage.calls.mostRecent()
+      .args[0] as ChatMessageDto;
+
+    // Simulate the server echoing the same message back over the WebSocket
+    privateMessages.next(sentMessage);
+    tick();
+
+    expect(component.messages.length).toBe(1);
+    discardPeriodicTasks();
+  }));
+});

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -45,6 +45,7 @@ interface ChatMessageView {
   privateChatId?: number;
   groupId?: number | null;
   timestamp: string;
+  clientMessageId?: string;
 }
 
 interface EncryptedMessageBodyV1 {
@@ -415,6 +416,7 @@ export class PrivateChatDialogComponent
       privateChatId: message.privateChatId || undefined,
       groupId: message.groupId || undefined,
       timestamp,
+      clientMessageId: message.clientMessageId,
     };
   }
 
@@ -517,6 +519,7 @@ export class PrivateChatDialogComponent
         groupId: this.isGroupChat ? this.groupId : null,
         senderDeviceId: payload.senderDeviceId,
         e2eePayload: JSON.stringify(payload),
+        clientMessageId: crypto.randomUUID(),
       };
 
       const isConnected = await this.wsService.ensureConnected();
@@ -821,13 +824,19 @@ export class PrivateChatDialogComponent
   }
 
   private isDuplicateMessage(message: ChatMessageDto): boolean {
-    return this.messages.some(
-      (existing) =>
-        existing.privateChatId === message.privateChatId &&
-        existing.groupId === message.groupId &&
-        existing.senderUsername === message.senderUsername &&
-        existing.timestamp === message.timestamp,
-    );
+    if (message.clientMessageId) {
+        return this.messages.some(
+          (existing) => existing.clientMessageId === message.clientMessageId,
+        );
+      }
+
+      return this.messages.some(
+        (existing) =>
+          (existing.privateChatId ?? null) === (message.privateChatId ?? null) &&
+          (existing.groupId ?? null) === (message.groupId ?? null) &&
+          existing.senderUsername === message.senderUsername &&
+          existing.timestamp === message.timestamp,
+      );
   }
 
   getAvatarPicUrl(senderUsername: string | undefined): string | null {

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -825,18 +825,18 @@ export class PrivateChatDialogComponent
 
   private isDuplicateMessage(message: ChatMessageDto): boolean {
     if (message.clientMessageId) {
-        return this.messages.some(
-          (existing) => existing.clientMessageId === message.clientMessageId,
-        );
-      }
-
       return this.messages.some(
-        (existing) =>
-          (existing.privateChatId ?? null) === (message.privateChatId ?? null) &&
-          (existing.groupId ?? null) === (message.groupId ?? null) &&
-          existing.senderUsername === message.senderUsername &&
-          existing.timestamp === message.timestamp,
+        (existing) => existing.clientMessageId === message.clientMessageId,
       );
+    }
+
+    return this.messages.some(
+      (existing) =>
+        (existing.privateChatId ?? null) === (message.privateChatId ?? null) &&
+        (existing.groupId ?? null) === (message.groupId ?? null) &&
+        existing.senderUsername === message.senderUsername &&
+        existing.timestamp === message.timestamp,
+    );
   }
 
   getAvatarPicUrl(senderUsername: string | undefined): string | null {


### PR DESCRIPTION
## Summary
Sending a message in a group chat showed it twice in the sender's own view — the message was stored and delivered only once, the duplicate was a client-side rendering issue.

`isDuplicateMessage` in `private-chat-dialog.component.ts` compared `privateChatId`/`groupId` with strict equality. The locally-appended view held `privateChatId` as `undefined` (normalized by `toViewMessage`), while the server-echoed DTO carried `privateChatId: null`. Since `undefined === null` is `false`, the guard failed to detect the echo as a duplicate. The mirror-image issue existed for private chats with `groupId`.

Two changes fix this:
1. Normalize ids with nullish coalescing (`?? null`) before comparing, and compare timestamps as parsed instants rather than raw strings (defends against the `Date.toISOString()` vs `Instant.toString()` formatting difference).
2. Added a client-generated `clientMessageId` (UUID), attached on send, persisted, and echoed back unchanged — a more durable dedup key than field-matching. Falls back to the normalized comparison for messages without one (backward compatible, nullable column).

## Linked issue
Closes #298

## How to test
1. Start the stack (`docker compose up -d`, backend, frontend).
2. Open two browser sessions as different users, join/create a group chat with both.
3. Send a message from User A — confirm it appears **once** for A and once for B.
4. Repeat in a private (1:1) chat to cover the mirror-image `groupId` case.
5. Unit tests:
   - Backend: `./mvnw test -Dtest=ChatServiceTest`
   - Frontend: `ng test --include='**/private-chat-dialog.component.spec.ts'`

## Notes / Risk
- **No migration needed** — `spring.jpa.hibernate.ddl-auto=update` auto-applies the new nullable `client_message_id` column on `chat_message`.
- **Backward compatible** — existing messages without a `clientMessageId` fall back to the original (now-fixed) field comparison, so no data backfill required.
- Low risk: additive schema change, no removed/renamed fields, no breaking API changes.
