### PR TITLE
fix(frontend): add scroll area to security activity timeline

### DIFF
--- a/frontend/src/app/pages/security-activity/security-activity.component.scss
+++ b/frontend/src/app/pages/security-activity/security-activity.component.scss
@@ -68,6 +68,10 @@
 .timeline-wrap {
   position: relative;
   padding-left: 2rem;
+  max-height: min(65vh, 720px);
+  overflow-y: auto;
+  padding-right: 0.75rem;
+  scrollbar-gutter: stable;
 }
 
 .timeline {


### PR DESCRIPTION
## Summary
Added a maximum height and vertical scrolling to the security activity timeline. The page remains compact while all loaded events remain accessible.

## Linked issue

Closes #301 

## How to test
a. Open the Security Activity page.
b. Ensure more events exist than fit in the timeline area.
c. Verify the timeline scrolls independently.
d. Verify the badge still shows the total number of loaded events.

## Notes / Risk
CSS-only change. No migrations, feature flags, or rollout changes.