### PR TITLE
Fix editor reloading folder while typing (#300)

### DIFF
--- a/frontend/src/app/pages/cloud/cloud.component.spec.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.spec.ts
@@ -490,7 +490,7 @@ describe('CloudComponent Unsaved Changes Flow', () => {
       });
     });
 
-    it('should transition saveStatus through unsaved -> saving -> saved during autosave', async () => {
+    it('does not autosave or reload the folder while typing (#300 regression)', () => {
       component.showFileEditor = true;
       component.newFileName = 'note.md';
       component.fileContent = 'new markdown';
@@ -498,19 +498,36 @@ describe('CloudComponent Unsaved Changes Flow', () => {
       component.originalFileName = 'note.md';
       component.currentFolder = { path: '/root', name: 'root' } as any;
 
-      cloudMock.uploadFile.and.returnValue(of({} as any));
+      component.onContentChange();
+
+      // Dirty state still tracked correctly, with no background save kicked off.
+      expect(component.saveStatus).toBe('unsaved');
+      expect(component.isEditorDirty).toBeTrue();
+
+      // Well past the old 2s autosave delay — nothing should fire.
+      jasmine.clock().tick(5000);
+
+      expect(cloudMock.uploadFile).not.toHaveBeenCalled();
+      expect(cloudMock.getFolderByPath).not.toHaveBeenCalled();
+      expect(component.saveStatus).toBe('unsaved');
+      expect(component.fileContent).toBe('new markdown');
+      expect(component.originalFileContent).toBe(''); // unchanged: no autosave wrote it
+    });
+
+    it('still updates the local outline and preview while typing, without saving', () => {
+      component.showFileEditor = true;
+      component.newFileName = 'note.md';
+      component.originalFileName = 'note.md';
+      component.originalFileContent = '';
+      component.fileContent = '# New Heading\nbody text';
+      component.currentFolder = { path: '/root', name: 'root' } as any;
 
       component.onContentChange();
-      expect(component.saveStatus).toBe('unsaved');
 
-      jasmine.clock().tick(2000);
-
-      // Wait for async autosave Promise to resolve
-      await component.autosaveFile();
-
-      expect(component.saveStatus).toBe('saved');
-      expect(component.originalFileContent).toBe('new markdown');
-      expect(component.isEditorDirty).toBeFalse();
+      expect(component.outline).toEqual([{ text: 'New Heading', level: 1 }]);
+      expect(component.previewHtml.toString()).toContain('New Heading');
+      expect(cloudMock.uploadFile).not.toHaveBeenCalled();
+      expect(cloudMock.getFolderByPath).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -113,7 +113,6 @@ export class CloudComponent implements OnInit, OnDestroy {
   originalFileContent = '';
   outline: { text: string; level: number }[] = [];
   saveStatus: 'saved' | 'saving' | 'unsaved' = 'saved';
-  autosaveTimer: ReturnType<typeof setTimeout> | null = null;
   editorMode: 'edit' | 'preview' | 'split' = 'edit';
   previewHtml: SafeHtml = '';
 
@@ -1788,78 +1787,14 @@ export class CloudComponent implements OnInit, OnDestroy {
   }
 
   onContentChange() {
-    if (this.isEditorDirty) {
-      this.saveStatus = 'unsaved';
-      this.triggerAutosave();
-    } else {
-      this.saveStatus = 'saved';
-      if (this.autosaveTimer) {
-        clearTimeout(this.autosaveTimer);
-        this.autosaveTimer = null;
-      }
-    }
+    this.saveStatus = this.isEditorDirty ? 'unsaved' : 'saved';
     if (this.isMarkdownFile(this.newFileName)) {
       this.updateOutline();
       this.updatePreview();
     }
   }
 
-  triggerAutosave() {
-    if (this.autosaveTimer) {
-      clearTimeout(this.autosaveTimer);
-    }
-    this.autosaveTimer = setTimeout(() => {
-      this.autosaveFile();
-    }, 2000);
-  }
-
-  async autosaveFile() {
-    const nameToSave = this.newFileName.trim();
-    if (!nameToSave || !this.isEditorDirty) return;
-
-    // Background autosave only saves content edits under existing filename.
-    // File renames are handled when the user explicitly clicks Save.
-    if (this.editingFile && this.fileContent === this.originalFileContent) {
-      return;
-    }
-
-    this.saveStatus = 'saving';
-
-    try {
-      const targetName = this.editingFile ? this.editingFile.name : nameToSave;
-      const currentPath = this.getRelativePath(this.currentFolder?.path || '/');
-      const fileBlob = new Blob([this.fileContent], { type: 'text/plain' });
-      const file = new File([fileBlob], targetName);
-      await firstValueFrom(this.cloudService.uploadFile(currentPath, file));
-
-      if (!this.editingFile) {
-        const relativeTarget = this.joinRelativePath(currentPath, targetName);
-        this.editingFile = {
-          path: relativeTarget,
-          name: targetName,
-          size: fileBlob.size,
-          mimeType: 'text/markdown',
-        };
-        this.newFileName = targetName;
-        this.originalFileName = targetName;
-      }
-
-      this.originalFileContent = this.fileContent;
-      this.saveStatus = 'saved';
-      this.reloadCurrentFolder();
-    } catch (err: unknown) {
-      this.saveStatus = 'unsaved';
-      console.error('Autosave failed:', err);
-      this.toast.error('Autosave failed', this.getErrorMessage(err));
-    }
-  }
-
   closeFileEditor() {
-    if (this.autosaveTimer) {
-      clearTimeout(this.autosaveTimer);
-      this.autosaveTimer = null;
-    }
-
     this.showFileEditor = false;
     this.editingFile = null;
     this.newFileName = '';


### PR DESCRIPTION
## Summary
Removes the cloud editor's autosave timer, which was silently reloading the current folder every ~2s of typing, causing the file list/table to flicker while the user is still editing.

Root cause: `autosaveFile()` uploaded the file content in the background and then called `reloadCurrentFolder()` on success. This ran on a 2-second debounce (`triggerAutosave()`) from every `onContentChange()` keystroke, so any sustained typing triggered repeated background folder reloads.

Fix follows the approach suggested in the issue: remove the autosave timer and `autosaveFile()`/`triggerAutosave()` methods entirely, rather than just dropping the reload call. Saving now happens only through the existing explicit Save action (`saveFile()`), which is untouched.

Preserved, unchanged:
- Dirty-state tracking (`saveStatus`, `isEditorDirty`) — still updates live as the user types
- Close-confirmation guard (`requestCloseFileEditor`, `onFileEditorHide`, `canDeactivate`, `warnBeforeUnload`) — still prompts on any unsaved exit path
- Local Markdown outline/preview updates (`updateOutline()`, `updatePreview()`) — still update on every keystroke via `onContentChange()`, since these don't touch the server
- New-file creation and preview behavior

## Linked issue
Closes #300

## How to test
1. Open the Cloud editor on an existing (or new) Markdown/text file.
2. Type continuously for more than 2 seconds.
3. **Before this fix:** the folder table below/behind the editor would flicker/reload mid-typing.
4. **After this fix:** no reload occurs while typing; the "unsaved" status indicator still updates correctly, and the outline/preview panels still update live.
5. Click **Save** — content is written and the folder list refreshes as expected (unchanged explicit-save behavior).
6. Try closing the editor with unsaved changes (Cancel button, dialog dismiss, and a full page refresh/tab close) — confirmation prompt still appears in all three paths.

Unit tests: `cloud.component.spec.ts` → `CloudComponent Unsaved Changes Flow > Markdown Workspace Mode`
- `does not autosave or reload the folder while typing (#300 regression)` — asserts no `uploadFile`/`getFolderByPath` call after 5s of simulated typing, and that `saveStatus` stays `'unsaved'`.
- `still updates the local outline and preview while typing, without saving` — asserts outline/preview still update locally with no network calls.

## Notes / Risk
- Low risk: this only removes a background-save code path; the explicit Save flow (`saveFile()`) is untouched.
- Behavior change: files are no longer saved automatically in the background. Users must click Save (or will be prompted on exit) to persist changes. This matches the fix suggested in the linked issue.
- Unrelated to this change: there's a pre-existing test failure in `CloudComponent unsaved-edit guard > folder download > downloads the folder as a zip archive...`, caused by `jasmine.createSpyObj` returning a non-DOM object passed to `document.body.appendChild`. Not touched by this PR; flagged separately.
