### PR TITLE
fix(cloud): apply ::ng-deep to markdown preview styles (#299)

### DIFF
--- a/frontend/src/app/pages/cloud/cloud.component.scss
+++ b/frontend/src/app/pages/cloud/cloud.component.scss
@@ -541,7 +541,7 @@ $font-mono: ui-monospace, monospace;
   margin-bottom: 0.15rem;
 }
 
-.markdown-preview {
+:host ::ng-deep .markdown-preview {
   width: 100%;
   height: 100%;
   min-height: 14rem;


### PR DESCRIPTION
## Summary
Applied the `::ng-deep` combinator to the `.markdown-preview` descendant selectors in `cloud.component.scss`. This allows component styling rules to penetrate Angular's emulated view encapsulation and properly style HTML elements dynamically rendered via `[innerHTML]` in both the preview tab and split view.

## Linked issue
Closes #299 

## How to test
1. Open the Cloud editor and open a Markdown file containing headings (`# H1`, `## H2`), lists (ordered and unordered), fenced code blocks, blockquotes, tables, and links.
2. Toggle the **Preview** tab and verify that typography, list bullets/numbers, code block formatting, and table borders render with their intended styles.
3. Switch to the Split view and confirm the styles match the preview tab identically.

## Notes
The change is strictly scoped to descendant styles within the `.markdown-preview` container and does not affect global stylesheets or unrelated components.
