### PR TITLE
Feature issue#111

### DIFF
--- a/frontend/src/app/models/dtos/SecureSendLinkDto.ts
+++ b/frontend/src/app/models/dtos/SecureSendLinkDto.ts
@@ -8,11 +8,14 @@ export interface SecureSendLinkDto {
   resourceType?: SharedResourceType;
   shareUrl?: string;
   token?: string;
-  expiresAt: string | Date;
+  /** Null means the link never expires. */
+  expiresAt: string | Date | null;
   hasPassword?: boolean;
   isRevoked?: boolean;
   revokedAt?: string | Date | null;
   createdAt: string | Date;
+  /** Null if the link has never been opened. */
+  lastAccessedAt?: string | Date | null;
 }
 
 /**
@@ -29,6 +32,7 @@ export interface PublicShareDto {
 
 export interface CreateSecureSendRequestDto {
   filePath: string;
-  expiresAt: string;
+  /** Omit or null for a link that never expires. */
+  expiresAt: string | null;
   password?: string;
 }

--- a/frontend/src/app/pages/cloud/cloud.component.ts
+++ b/frontend/src/app/pages/cloud/cloud.component.ts
@@ -161,6 +161,7 @@ export class CloudComponent implements OnInit, OnDestroy {
     { label: '1 Day', value: 1440 },
     { label: '7 Days', value: 10080 },
     { label: '30 Days', value: 43200 },
+    { label: 'Never', value: 0 },
   ];
 
   newFolderName = '';
@@ -1966,11 +1967,13 @@ export class CloudComponent implements OnInit, OnDestroy {
 
     this.creatingShareLink = true;
     const { path, name } = this.selectedFileForShare;
+    const expiryMinutes = Number(this.shareExpiryMinutes);
+    const neverExpires = expiryMinutes === 0;
 
     this.cloudService
       .createSecureSendLink(
         path,
-        Number(this.shareExpiryMinutes),
+        neverExpires ? null : expiryMinutes,
         this.sharePassword,
       )
       .pipe(finalize(() => (this.creatingShareLink = false)))

--- a/frontend/src/app/pages/cloud/shared-links/shared-links.component.html
+++ b/frontend/src/app/pages/cloud/shared-links/shared-links.component.html
@@ -129,6 +129,7 @@
           <th>Shared item</th>
           <th>Shared</th>
           <th>Expires</th>
+          <th>Last opened</th>
           <th>Protection</th>
           <th>Status</th>
           <th class="text-right">Actions</th>
@@ -152,7 +153,18 @@
             {{ link.fileName }}
           </td>
           <td class="shared-muted">{{ link.createdAt | date: "medium" }}</td>
-          <td class="shared-muted">{{ link.expiresAt | date: "medium" }}</td>
+          <td class="shared-muted">
+            <span *ngIf="link.expiresAt">{{
+              link.expiresAt | date: "medium"
+            }}</span>
+            <span *ngIf="!link.expiresAt">Never</span>
+          </td>
+          <td class="shared-muted">
+            <span *ngIf="link.lastAccessedAt">{{
+              link.lastAccessedAt | date: "medium"
+            }}</span>
+            <span *ngIf="!link.lastAccessedAt">Never opened</span>
+          </td>
           <td class="shared-muted">
             <span *ngIf="link.hasPassword"
               ><i class="pi pi-lock"></i> Password</span
@@ -180,13 +192,25 @@
                 tooltipPosition="top"
                 ariaLabel="Revoke share link"
               ></p-button>
+              <p-button
+                label="Delete"
+                icon="pi pi-trash"
+                severity="danger"
+                styleClass="p-button-text p-button-sm"
+                [disabled]="isProcessing(link.id)"
+                [loading]="isProcessing(link.id)"
+                (click)="confirmDeleteLink(link)"
+                pTooltip="Remove this link from your list permanently"
+                tooltipPosition="top"
+                ariaLabel="Delete share link"
+              ></p-button>
             </div>
           </td>
         </tr>
       </ng-template>
       <ng-template pTemplate="emptymessage">
         <tr>
-          <td colspan="6" class="shared-empty text-xxs sm:text-xs">
+          <td colspan="7" class="shared-empty text-xxs sm:text-xs">
             You have not created any public links yet.
           </td>
         </tr>

--- a/frontend/src/app/pages/cloud/shared-links/shared-links.component.scss
+++ b/frontend/src/app/pages/cloud/shared-links/shared-links.component.scss
@@ -88,3 +88,30 @@
   gap: 0.5rem;
   flex-wrap: wrap;
 }
+
+.shared-badge {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 9999px;
+  text-transform: capitalize;
+
+  &.is-active {
+    background: var(--green-100, #dcfce7);
+    color: var(--green-700, #15803d);
+  }
+
+  &.is-expired {
+    background: var(--surface-200, #e5e7eb);
+    color: var(--surface-600, #4b5563);
+  }
+
+  &.is-revoked {
+    background: var(--red-100, #fee2e2);
+    color: var(--red-700, #b91c1c);
+  }
+
+  &.is-never-expires {
+    background: var(--blue-100, #dbeafe);
+    color: var(--blue-700, #1d4ed8);
+  }
+}

--- a/frontend/src/app/pages/cloud/shared-links/shared-links.component.ts
+++ b/frontend/src/app/pages/cloud/shared-links/shared-links.component.ts
@@ -129,12 +129,19 @@ export class SharedLinksComponent implements OnInit {
   // --- public links ----------------------------------------------------------
 
   isExpired(link: SecureSendLinkDto): boolean {
-    return new Date(link.expiresAt).getTime() <= Date.now();
+    return (
+      link.expiresAt != null && new Date(link.expiresAt).getTime() <= Date.now()
+    );
   }
 
-  linkStatus(link: SecureSendLinkDto): 'revoked' | 'expired' | 'active' {
+  linkStatus(
+    link: SecureSendLinkDto,
+  ): 'revoked' | 'expired' | 'active' | 'never-expires' {
     if (link.isRevoked) {
       return 'revoked';
+    }
+    if (link.expiresAt == null) {
+      return 'never-expires';
     }
     return this.isExpired(link) ? 'expired' : 'active';
   }
@@ -170,6 +177,40 @@ export class SharedLinksComponent implements OnInit {
           this.toast.error(
             'Revocation failed',
             'The share link could not be revoked.',
+          ),
+      });
+  }
+
+  confirmDeleteLink(link: SecureSendLinkDto): void {
+    this.confirmationService.confirm({
+      header: 'Delete share link',
+      message: `This permanently removes the link to "${link.fileName}" from your list. This cannot be undone.`,
+      icon: 'pi pi-exclamation-triangle',
+      acceptLabel: 'Delete',
+      rejectLabel: 'Cancel',
+      acceptButtonStyleClass: 'p-button-danger p-button-sm',
+      rejectButtonStyleClass: 'p-button-text p-button-sm',
+      accept: () => this.deleteLink(link),
+    });
+  }
+
+  private deleteLink(link: SecureSendLinkDto): void {
+    this.processingIds.add(link.id);
+    this.cloudService
+      .deleteSecureSendLink(link.id)
+      .pipe(finalize(() => this.processingIds.delete(link.id)))
+      .subscribe({
+        next: () => {
+          this.links = this.links.filter((l) => l.id !== link.id);
+          this.toast.success(
+            'Link deleted',
+            `The share link for "${link.fileName}" has been removed.`,
+          );
+        },
+        error: () =>
+          this.toast.error(
+            'Delete failed',
+            'The share link could not be deleted.',
           ),
       });
   }

--- a/frontend/src/app/services/cloud.service.ts
+++ b/frontend/src/app/services/cloud.service.ts
@@ -33,6 +33,7 @@ interface RawSecureSendResponse {
   isRevoked?: boolean;
   revokedAt?: string | null;
   createdAt?: string;
+  lastAccessedAt?: string | null;
 }
 
 @Injectable({
@@ -264,13 +265,14 @@ export class CloudService {
 
   createSecureSendLink(
     filePath: string,
-    expiryMinutes = 1440,
+    expiryMinutes: number | null = 1440,
     password?: string,
   ): Observable<SecureSendLinkDto> {
     const normPath = this.normalizePath(filePath);
-    const expiresAt = new Date(
-      Date.now() + expiryMinutes * 60_000,
-    ).toISOString();
+    const expiresAt =
+      expiryMinutes == null
+        ? null
+        : new Date(Date.now() + expiryMinutes * 60_000).toISOString();
     const payload: CreateSecureSendRequestDto = {
       filePath: normPath,
       expiresAt,
@@ -299,6 +301,13 @@ export class CloudService {
     return this.http.delete<void>(`${this.apiUrl}/secure-sends/${encodedId}`);
   }
 
+  deleteSecureSendLink(id: string): Observable<void> {
+    const encodedId = encodeURIComponent(id);
+    return this.http.delete<void>(
+      `${this.apiUrl}/secure-sends/${encodedId}/permanent`,
+    );
+  }
+
   private mapSecureSendLink(
     res: RawSecureSendResponse,
     defaultPath = '',
@@ -322,7 +331,7 @@ export class CloudService {
       fileName,
       shareUrl,
       token,
-      expiresAt: res?.expiresAt || '',
+      expiresAt: res?.expiresAt ?? null,
       hasPassword: Boolean(
         res?.passwordProtected ??
         res?.hasPassword ??
@@ -332,6 +341,7 @@ export class CloudService {
       isRevoked: Boolean(res?.revoked ?? res?.isRevoked ?? false),
       revokedAt: res?.revokedAt || null,
       createdAt: res?.createdAt || '',
+      lastAccessedAt: res?.lastAccessedAt ?? null,
     };
   }
 }


### PR DESCRIPTION
## Summary

Adds the frontend UI for the two backend behaviors added in https://github.com/Vault-Web/cloud-page/issues/111: creating a link with no expiry ("Never"), and permanently deleting a link, distinct from the existing revoke.

- `expiryOptions` on the create-share dialog gains a "Never" option. `createSecureSendLink()` now accepts `expiryMinutes: number | null`, passing `expiresAt: null` straight through when "Never" is selected instead of computing a future ISO timestamp.
- `SecureSendLinkDto.expiresAt` is now `string | Date | null`, and `mapSecureSendLink()` preserves a genuinely missing `expiresAt` as `null` (previously coerced to `''`, which broke expiry checks against a never-expiring link).
- New `lastAccessedAt` field on `SecureSendLinkDto`, surfaced as a "Last opened" column on the Public links table, so an owner can spot stale links now that links can live indefinitely.
- `linkStatus()` gains a `never-expires` state (styled distinctly, blue) alongside the existing `active`/`expired`/`revoked` states; `isExpired()` is null-safe so a never-expiring link no longer reads as expired.
- New "Delete" button next to the existing "Revoke" button on each public link row, calling a new `deleteSecureSendLink()` → `DELETE /secure-sends/{id}/permanent`. Unlike Revoke, Delete is enabled regardless of link status, since its purpose is tidying up stale/dead links (including already-revoked or expired ones). The existing revoke flow and its endpoint are untouched.

## Linked issue

Closes #111

## How to test

1. Open the create-share dialog on any file, select "Never" from the expiry dropdown, and create the link.
2. Go to Sharing → Public links: confirm the row shows "Never" in the Expires column and "Never opened" under Last opened.
3. Open the generated link once, then hit Refresh on the Sharing page: confirm Last opened now shows a real timestamp.
4. Click Delete on that link: confirm it disappears from the list immediately, and that opening the same link afterward fails (unavailable), not just after the nightly cleanup job runs.
5. Confirm Revoke still behaves exactly as before on a link with a normal (non-null) expiry — no regression.

## Notes / Risk

- Depends on the backend changes in https://github.com/Vault-Web/cloud-page/pull/120 (nullable `expiresAt`, `lastAccessedAt` tracking, and the new `DELETE /secure-sends/{id}/permanent` endpoint) — needs that PR merged/deployed first, or this UI will call an endpoint that doesn't exist yet.
- No new dependencies. Purely additive to the existing Sharing page — no changes to unrelated flows (member shares, "Shared with me").