### PR TITLE
feat: add security activity filters and failed login hint

### DIFF
--- a/frontend/src/app/pages/security-activity/security-activity.component.html
+++ b/frontend/src/app/pages/security-activity/security-activity.component.html
@@ -20,9 +20,7 @@
             security.
           </p>
         </div>
-        <span class="badge"
-          >{{ filteredEvents.length }} of {{ events.length }} events</span
-        >
+        <span class="badge">{{ filteredEvents.length }} / {{ events.length }} events</span>
       </header>
 
       <div class="filters" *ngIf="events.length > 0">

--- a/frontend/src/app/pages/security-activity/security-activity.component.html
+++ b/frontend/src/app/pages/security-activity/security-activity.component.html
@@ -64,8 +64,8 @@
         <div>
           <strong>Repeated failed login attempts</strong>
           <p>
-            {{ failedLoginStreak }} failed login attempts occurred in a row.
-            If you do not recognize them, consider changing your password.
+            {{ failedLoginStreak }} failed login attempts occurred in a row. If
+            you do not recognize them, consider changing your password.
           </p>
         </div>
       </div>

--- a/frontend/src/app/pages/security-activity/security-activity.component.html
+++ b/frontend/src/app/pages/security-activity/security-activity.component.html
@@ -62,9 +62,6 @@
             If you do not recognize them, consider changing your password.
           </p>
         </div>
-        <a routerLink="/settings/security" class="security-action-link">
-          Review security
-        </a>
       </div>
 
       <div *ngIf="events.length === 0" class="empty-state">

--- a/frontend/src/app/pages/security-activity/security-activity.component.html
+++ b/frontend/src/app/pages/security-activity/security-activity.component.html
@@ -20,9 +20,9 @@
             security.
           </p>
         </div>
-        <span class="badge">
-          {{ filteredEvents.length }} / {{ events.length }} events
-        </span>
+        <span class="badge"
+          >{{ filteredEvents.length }} / {{ events.length }} events</span
+        >
       </header>
 
       <div class="filters" *ngIf="events.length > 0">

--- a/frontend/src/app/pages/security-activity/security-activity.component.html
+++ b/frontend/src/app/pages/security-activity/security-activity.component.html
@@ -20,18 +20,69 @@
             security.
           </p>
         </div>
-        <span class="badge">{{ events.length }} events</span>
+        <span class="badge">{{ filteredEvents.length }} of {{ events.length }} events</span>
       </header>
+
+      <div class="filters" *ngIf="events.length > 0">
+        <div class="filter-group">
+          <label for="event-type-filter">Event type</label>
+          <select id="event-type-filter" [(ngModel)]="selectedEventType">
+            <option value="ALL">All event types</option>
+            <option *ngFor="let type of eventTypes" [value]="type">
+              {{ getFriendlyEventType(type) }}
+            </option>
+          </select>
+        </div>
+
+        <div class="filter-group">
+          <label for="status-filter">Status</label>
+          <select id="status-filter" [(ngModel)]="selectedStatus">
+            <option value="ALL">All statuses</option>
+            <option value="SUCCESS">Successful</option>
+            <option value="FAILURE">Failed attempts</option>
+          </select>
+        </div>
+
+        <button
+          *ngIf="selectedEventType !== 'ALL' || selectedStatus !== 'ALL'"
+          class="clear-filter-btn"
+          type="button"
+          (click)="clearFilters()"
+        >
+          Clear filters
+        </button>
+      </div>
+
+      <div *ngIf="hasFailedLoginStreak" class="failed-login-alert" role="status">
+        <i class="pi pi-exclamation-triangle"></i>
+        <div>
+          <strong>Repeated failed login attempts</strong>
+          <p>
+            {{ failedLoginStreak }} failed login attempts occurred in a row.
+            If you do not recognize them, consider changing your password.
+          </p>
+        </div>
+        <a routerLink="/settings/security" class="security-action-link">
+          Review security
+        </a>
+      </div>
 
       <div *ngIf="events.length === 0" class="empty-state">
         <p>No security activity logged yet.</p>
       </div>
 
-      <div class="timeline-wrap" *ngIf="events.length > 0">
+      <div *ngIf="events.length > 0 && filteredEvents.length === 0" class="empty-state">
+        <p>No events match the selected filters.</p>
+        <button class="retry-btn" type="button" (click)="clearFilters()">
+          Clear filters
+        </button>
+      </div>
+
+      <div class="timeline-wrap" *ngIf="filteredEvents.length > 0">
         <ul class="timeline">
           <li
             class="timeline-entry"
-            *ngFor="let event of events; trackBy: trackById"
+            *ngFor="let event of filteredEvents; trackBy: trackById"
             [class.highlighted]="isHighlightEvent(event.eventType)"
           >
             <div class="dot-container">

--- a/frontend/src/app/pages/security-activity/security-activity.component.html
+++ b/frontend/src/app/pages/security-activity/security-activity.component.html
@@ -20,7 +20,9 @@
             security.
           </p>
         </div>
-        <span class="badge">{{ filteredEvents.length }} / {{ events.length }} events</span>
+        <span class="badge">
+          {{ filteredEvents.length }} / {{ events.length }} events
+        </span>
       </header>
 
       <div class="filters" *ngIf="events.length > 0">

--- a/frontend/src/app/pages/security-activity/security-activity.component.html
+++ b/frontend/src/app/pages/security-activity/security-activity.component.html
@@ -20,7 +20,9 @@
             security.
           </p>
         </div>
-        <span class="badge">{{ filteredEvents.length }} of {{ events.length }} events</span>
+        <span class="badge"
+          >{{ filteredEvents.length }} of {{ events.length }} events</span
+        >
       </header>
 
       <div class="filters" *ngIf="events.length > 0">
@@ -53,7 +55,11 @@
         </button>
       </div>
 
-      <div *ngIf="hasFailedLoginStreak" class="failed-login-alert" role="status">
+      <div
+        *ngIf="hasFailedLoginStreak"
+        class="failed-login-alert"
+        role="status"
+      >
         <i class="pi pi-exclamation-triangle"></i>
         <div>
           <strong>Repeated failed login attempts</strong>
@@ -68,7 +74,10 @@
         <p>No security activity logged yet.</p>
       </div>
 
-      <div *ngIf="events.length > 0 && filteredEvents.length === 0" class="empty-state">
+      <div
+        *ngIf="events.length > 0 && filteredEvents.length === 0"
+        class="empty-state"
+      >
         <p>No events match the selected filters.</p>
         <button class="retry-btn" type="button" (click)="clearFilters()">
           Clear filters

--- a/frontend/src/app/pages/security-activity/security-activity.component.scss
+++ b/frontend/src/app/pages/security-activity/security-activity.component.scss
@@ -37,7 +37,7 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 2rem;
+  margin-bottom: 1.25rem;
   padding-bottom: 1rem;
   border-bottom: 1px solid var(--color-border);
 
@@ -55,6 +55,90 @@
   color: var(--color-text-secondary);
   font-size: 0.85rem;
   font-weight: 600;
+  white-space: nowrap;
+}
+
+.filters {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1rem;
+  margin-bottom: 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.9rem;
+  background: var(--color-background-secondary);
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 190px;
+  flex: 1;
+
+  label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+  }
+
+  select {
+    width: 100%;
+    padding: 0.65rem 0.75rem;
+    border-radius: 0.6rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font: inherit;
+    cursor: pointer;
+  }
+}
+
+.clear-filter-btn {
+  padding: 0.65rem 0.9rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.6rem;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-surface-hover);
+    color: var(--color-text-primary);
+  }
+}
+
+.failed-login-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 1rem;
+  margin-bottom: 1.25rem;
+  border: 1px solid color-mix(in srgb, #ef4444 35%, var(--color-border));
+  border-radius: 0.9rem;
+  background: color-mix(in srgb, #ef4444 8%, var(--color-surface));
+  color: var(--color-text-primary);
+
+  > i {
+    margin-top: 0.15rem;
+    color: #ef4444;
+  }
+
+  strong {
+    display: block;
+    margin-bottom: 0.25rem;
+  }
+
+  p {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
 }
 
 .empty-state {
@@ -234,13 +318,14 @@
     color: #10b981;
   }
 
-  &.failure {
+  &.failure,
+  &.failed,
+  &.error {
     background: rgba(239, 68, 68, 0.15);
     color: #ef4444;
   }
 }
 
-// Skeletons and helper states
 .loading-state .skeleton {
   border-radius: 1rem;
   background: linear-gradient(
@@ -285,5 +370,33 @@
 
   &:hover {
     background: var(--color-primary-hover);
+  }
+}
+
+@media (max-width: 640px) {
+  .glass-card {
+    padding: 1.25rem;
+  }
+
+  .section-header {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .filters {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .filter-group {
+    min-width: 0;
+  }
+
+  .clear-filter-btn {
+    width: 100%;
+  }
+
+  .failed-login-alert {
+    flex-direction: column;
   }
 }

--- a/frontend/src/app/pages/security-activity/security-activity.component.ts
+++ b/frontend/src/app/pages/security-activity/security-activity.component.ts
@@ -15,6 +15,8 @@ export class SecurityActivityComponent implements OnInit {
   events: SecurityEventDto[] = [];
   isLoading = true;
   error: string | null = null;
+  selectedEventType = 'ALL';
+  selectedStatus = 'ALL';
 
   constructor(
     private userService: UserService,
@@ -47,6 +49,51 @@ export class SecurityActivityComponent implements OnInit {
 
   retry(): void {
     this.loadSecurityActivity();
+  }
+
+  get eventTypes(): string[] {
+    return [...new Set(this.events.map((event) => event.eventType))].sort();
+  }
+
+  get filteredEvents(): SecurityEventDto[] {
+    return this.events.filter((event) => {
+      const matchesType =
+        this.selectedEventType === 'ALL' ||
+        event.eventType === this.selectedEventType;
+      const matchesStatus =
+        this.selectedStatus === 'ALL' ||
+        event.status.toUpperCase() === this.selectedStatus;
+      return matchesType && matchesStatus;
+    });
+  }
+
+  get failedLoginStreak(): number {
+    let streak = 0;
+    let longestStreak = 0;
+
+    for (const event of this.events) {
+      const isFailedLogin =
+        event.eventType === 'LOGIN' &&
+        event.status.toUpperCase() === 'FAILURE';
+
+      if (isFailedLogin) {
+        streak += 1;
+        longestStreak = Math.max(longestStreak, streak);
+      } else if (event.eventType === 'LOGIN') {
+        streak = 0;
+      }
+    }
+
+    return longestStreak;
+  }
+
+  get hasFailedLoginStreak(): boolean {
+    return this.failedLoginStreak >= 3;
+  }
+
+  clearFilters(): void {
+    this.selectedEventType = 'ALL';
+    this.selectedStatus = 'ALL';
   }
 
   getFriendlyEventType(type: string): string {

--- a/frontend/src/app/pages/security-activity/security-activity.component.ts
+++ b/frontend/src/app/pages/security-activity/security-activity.component.ts
@@ -95,7 +95,11 @@ export class SecurityActivityComponent implements OnInit {
 
   isFailedStatus(status: string): boolean {
     const normalized = status.toUpperCase();
-    return normalized === 'FAILURE' || normalized === 'FAILED' || normalized === 'ERROR';
+    return (
+      normalized === 'FAILURE' ||
+      normalized === 'FAILED' ||
+      normalized === 'ERROR'
+    );
   }
 
   clearFilters(): void {

--- a/frontend/src/app/pages/security-activity/security-activity.component.ts
+++ b/frontend/src/app/pages/security-activity/security-activity.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { UserService, SecurityEventDto } from '../../services/user.service';
 import { UiToastService } from '../../core/services/ui-toast.service';
@@ -7,7 +8,7 @@ import { UiToastService } from '../../core/services/ui-toast.service';
 @Component({
   selector: 'app-security-activity',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, FormsModule, RouterModule],
   templateUrl: './security-activity.component.html',
   styleUrl: './security-activity.component.scss',
 })
@@ -62,7 +63,9 @@ export class SecurityActivityComponent implements OnInit {
         event.eventType === this.selectedEventType;
       const matchesStatus =
         this.selectedStatus === 'ALL' ||
-        event.status.toUpperCase() === this.selectedStatus;
+        (this.selectedStatus === 'FAILURE'
+          ? this.isFailedStatus(event.status)
+          : event.status.toUpperCase() === this.selectedStatus);
       return matchesType && matchesStatus;
     });
   }
@@ -73,8 +76,7 @@ export class SecurityActivityComponent implements OnInit {
 
     for (const event of this.events) {
       const isFailedLogin =
-        event.eventType === 'LOGIN' &&
-        event.status.toUpperCase() === 'FAILURE';
+        event.eventType === 'LOGIN' && this.isFailedStatus(event.status);
 
       if (isFailedLogin) {
         streak += 1;
@@ -89,6 +91,11 @@ export class SecurityActivityComponent implements OnInit {
 
   get hasFailedLoginStreak(): boolean {
     return this.failedLoginStreak >= 3;
+  }
+
+  isFailedStatus(status: string): boolean {
+    const normalized = status.toUpperCase();
+    return normalized === 'FAILURE' || normalized === 'FAILED' || normalized === 'ERROR';
   }
 
   clearFilters(): void {


### PR DESCRIPTION
## Summary
- add event-type and status filters to the security activity page
- add a clear-filters control and filtered event count
- highlight repeated failed login attempts when three or more occur consecutively
- keep the existing activity API and timeline rendering intact

## Issue
Closes #307

## Scope
The issue notes that filters and the failed-attempt hint carry the most value; pagination/older-event access and follow-up security actions are left for a follow-up change.