### PR TITLE
feat(chat): add rich-text Markdown support

### DIFF
--- a/frontend/src/app/pages/private-chat-dialog/chat-markdown-component.spec.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-markdown-component.spec.ts
@@ -1,0 +1,60 @@
+import { DomSanitizer } from '@angular/platform-browser';
+import { PrivateChatDialogComponent } from './private-chat-dialog.component';
+
+describe('PrivateChatDialogComponent Markdown formatting', () => {
+  it('renders Markdown through formatMessage and preserves the SafeHtml contract', () => {
+    const sanitizer = {
+      bypassSecurityTrustHtml: jasmine.createSpy('bypassSecurityTrustHtml'),
+    } as unknown as DomSanitizer;
+    const trustedHtml = {};
+    sanitizer.bypassSecurityTrustHtml = jasmine
+      .createSpy('bypassSecurityTrustHtml')
+      .and.returnValue(trustedHtml as any);
+
+    const component = new PrivateChatDialogComponent(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      sanitizer,
+    );
+
+    const result = component.formatMessage('**bold**');
+
+    expect(result).toBe(trustedHtml as any);
+    expect(sanitizer.bypassSecurityTrustHtml).toHaveBeenCalledTimes(1);
+    expect(sanitizer.bypassSecurityTrustHtml).toHaveBeenCalledWith(
+      jasmine.stringContaining('<strong>bold</strong>'),
+    );
+  });
+
+  it('reuses the formatted message cache for repeated content', () => {
+    const sanitizer = {
+      bypassSecurityTrustHtml: jasmine.createSpy('bypassSecurityTrustHtml'),
+    } as unknown as DomSanitizer;
+    const trustedHtml = {};
+    sanitizer.bypassSecurityTrustHtml = jasmine
+      .createSpy('bypassSecurityTrustHtml')
+      .and.returnValue(trustedHtml as any);
+
+    const component = new PrivateChatDialogComponent(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      sanitizer,
+    );
+
+    const first = component.formatMessage('**bold**');
+    const second = component.formatMessage('**bold**');
+
+    expect(second).toBe(first);
+    expect(sanitizer.bypassSecurityTrustHtml).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/pages/private-chat-dialog/chat-markdown-component.spec.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-markdown-component.spec.ts
@@ -3,13 +3,11 @@ import { PrivateChatDialogComponent } from './private-chat-dialog.component';
 
 describe('PrivateChatDialogComponent Markdown formatting', () => {
   it('renders Markdown through formatMessage and preserves the SafeHtml contract', () => {
-    const sanitizer = {
-      bypassSecurityTrustHtml: jasmine.createSpy('bypassSecurityTrustHtml'),
-    } as unknown as DomSanitizer;
+    const sanitizer = jasmine.createSpyObj<DomSanitizer>('DomSanitizer', [
+      'bypassSecurityTrustHtml',
+    ]);
     const trustedHtml = {};
-    sanitizer.bypassSecurityTrustHtml = jasmine
-      .createSpy('bypassSecurityTrustHtml')
-      .and.returnValue(trustedHtml as any);
+    sanitizer.bypassSecurityTrustHtml.and.returnValue(trustedHtml as any);
 
     const component = new PrivateChatDialogComponent(
       {} as any,
@@ -32,13 +30,11 @@ describe('PrivateChatDialogComponent Markdown formatting', () => {
   });
 
   it('reuses the formatted message cache for repeated content', () => {
-    const sanitizer = {
-      bypassSecurityTrustHtml: jasmine.createSpy('bypassSecurityTrustHtml'),
-    } as unknown as DomSanitizer;
+    const sanitizer = jasmine.createSpyObj<DomSanitizer>('DomSanitizer', [
+      'bypassSecurityTrustHtml',
+    ]);
     const trustedHtml = {};
-    sanitizer.bypassSecurityTrustHtml = jasmine
-      .createSpy('bypassSecurityTrustHtml')
-      .and.returnValue(trustedHtml as any);
+    sanitizer.bypassSecurityTrustHtml.and.returnValue(trustedHtml as any);
 
     const component = new PrivateChatDialogComponent(
       {} as any,

--- a/frontend/src/app/pages/private-chat-dialog/chat-markdown.spec.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-markdown.spec.ts
@@ -1,0 +1,25 @@
+import { renderChatMarkdown } from './chat-markdown';
+
+describe('renderChatMarkdown', () => {
+  it('renders common Markdown formatting', () => {
+    const html = renderChatMarkdown(
+      '**bold**\n\n- one\n- two\n\n> quote\n\n`inline`\n\n```ts\nconst value = 1;\n```',
+    );
+
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<blockquote>');
+    expect(html).toContain('<code>inline</code>');
+    expect(html).toContain('<pre>');
+    expect(html).toContain('const value = 1;');
+  });
+
+  it('sanitizes HTML and dangerous links after Markdown parsing', () => {
+    const html = renderChatMarkdown(
+      '<img src=x onerror="alert(1)">\n\n[bad](javascript:alert(1))',
+    );
+
+    expect(html).not.toContain('onerror');
+    expect(html).not.toContain('javascript:');
+  });
+});

--- a/frontend/src/app/pages/private-chat-dialog/chat-markdown.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-markdown.ts
@@ -34,6 +34,10 @@ export function renderChatMarkdown(content: string): string {
     breaks: true,
     async: false,
   }) as string;
-  const cleanHtml = DOMPurify.sanitize(rendered);
+  const withSafeLinkAttributes = rendered.replace(
+    /<a\b(?![^>]*\btarget=)([^>]*)>/gi,
+    '<a target="_blank" rel="noopener noreferrer"$1>',
+  );
+  const cleanHtml = DOMPurify.sanitize(withSafeLinkAttributes);
   return `<div class="chat-markdown">${cleanHtml}</div>`;
 }

--- a/frontend/src/app/pages/private-chat-dialog/chat-markdown.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-markdown.ts
@@ -30,16 +30,10 @@ function installStyles(): void {
 
 export function renderChatMarkdown(content: string): string {
   installStyles();
-  const rendered = marked.parse(content ?? '', { async: false });
+  const rendered = marked.parse(content ?? '', {
+    breaks: true,
+    async: false,
+  }) as string;
   const cleanHtml = DOMPurify.sanitize(rendered);
   return `<div class="chat-markdown">${cleanHtml}</div>`;
 }
-
-void import('./private-chat-dialog.component').then(
-  ({ PrivateChatDialogComponent }) => {
-    const prototype = PrivateChatDialogComponent.prototype as unknown as {
-      formatMessage: (content?: string) => string;
-    };
-    prototype.formatMessage = (content = '') => renderChatMarkdown(content);
-  },
-);

--- a/frontend/src/app/pages/private-chat-dialog/chat-markdown.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-markdown.ts
@@ -35,9 +35,11 @@ export function renderChatMarkdown(content: string): string {
   return `<div class="chat-markdown">${cleanHtml}</div>`;
 }
 
-void import('./private-chat-dialog.component').then(({ PrivateChatDialogComponent }) => {
-  const prototype = PrivateChatDialogComponent.prototype as unknown as {
-    formatMessage: (content?: string) => string;
-  };
-  prototype.formatMessage = (content = '') => renderChatMarkdown(content);
-});
+void import('./private-chat-dialog.component').then(
+  ({ PrivateChatDialogComponent }) => {
+    const prototype = PrivateChatDialogComponent.prototype as unknown as {
+      formatMessage: (content?: string) => string;
+    };
+    prototype.formatMessage = (content = '') => renderChatMarkdown(content);
+  },
+);

--- a/frontend/src/app/pages/private-chat-dialog/chat-markdown.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-markdown.ts
@@ -30,7 +30,7 @@ function installStyles(): void {
 
 export function renderChatMarkdown(content: string): string {
   installStyles();
-  const rendered = marked.parse(content ?? '');
+  const rendered = marked.parse(content ?? '', { async: false });
   const cleanHtml = DOMPurify.sanitize(rendered);
   return `<div class="chat-markdown">${cleanHtml}</div>`;
 }

--- a/frontend/src/app/pages/private-chat-dialog/chat-markdown.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-markdown.ts
@@ -1,0 +1,43 @@
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+
+const MARKDOWN_STYLES = `
+.chat-bubble .chat-markdown { line-height: 1.5; }
+.chat-bubble .chat-markdown p { margin: 0.25rem 0; }
+.chat-bubble .chat-markdown p:first-child { margin-top: 0; }
+.chat-bubble .chat-markdown p:last-child { margin-bottom: 0; }
+.chat-bubble .chat-markdown ul, .chat-bubble .chat-markdown ol { margin: 0.35rem 0; padding-left: 1.25rem; }
+.chat-bubble .chat-markdown ul { list-style: disc; }
+.chat-bubble .chat-markdown ol { list-style: decimal; }
+.chat-bubble .chat-markdown li { margin: 0.15rem 0; }
+.chat-bubble .chat-markdown blockquote { margin: 0.5rem 0; padding-left: 0.75rem; border-left: 3px solid currentColor; opacity: 0.85; }
+.chat-bubble .chat-markdown code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 0.9em; padding: 0.1rem 0.3rem; border-radius: 0.25rem; background: color-mix(in srgb, currentColor 10%, transparent); }
+.chat-bubble .chat-markdown pre { margin: 0.5rem 0; padding: 0.65rem; overflow-x: auto; border-radius: 0.5rem; background: color-mix(in srgb, currentColor 10%, transparent); }
+.chat-bubble .chat-markdown pre code { padding: 0; background: transparent; }
+.chat-bubble .chat-markdown a { text-decoration: underline; overflow-wrap: anywhere; }
+`;
+
+let stylesInstalled = false;
+
+function installStyles(): void {
+  if (stylesInstalled || typeof document === 'undefined') return;
+  const style = document.createElement('style');
+  style.setAttribute('data-chat-markdown', 'true');
+  style.textContent = MARKDOWN_STYLES;
+  document.head.appendChild(style);
+  stylesInstalled = true;
+}
+
+export function renderChatMarkdown(content: string): string {
+  installStyles();
+  const rendered = marked.parse(content ?? '');
+  const cleanHtml = DOMPurify.sanitize(rendered);
+  return `<div class="chat-markdown">${cleanHtml}</div>`;
+}
+
+void import('./private-chat-dialog.component').then(({ PrivateChatDialogComponent }) => {
+  const prototype = PrivateChatDialogComponent.prototype as unknown as {
+    formatMessage: (content?: string) => string;
+  };
+  prototype.formatMessage = (content = '') => renderChatMarkdown(content);
+});

--- a/frontend/src/app/pages/private-chat-dialog/chat-reactions.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-reactions.ts
@@ -1,3 +1,5 @@
+import './chat-markdown';
+
 export interface ChatSticker {
   id: string;
   label: string;

--- a/frontend/src/app/pages/private-chat-dialog/chat-reactions.ts
+++ b/frontend/src/app/pages/private-chat-dialog/chat-reactions.ts
@@ -1,5 +1,3 @@
-import './chat-markdown';
-
 export interface ChatSticker {
   id: string;
   label: string;

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -33,7 +33,7 @@ import {
   findChatSticker,
 } from './chat-reactions';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import DOMPurify from 'dompurify';
+import { renderChatMarkdown } from './chat-markdown';
 
 interface ChatMessageView {
   kind: 'text' | 'sticker';
@@ -752,69 +752,24 @@ export class PrivateChatDialogComponent
     };
   }
 
-  private escapeHtml(text: string): string {
-    return text
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
   /**
-   * Rendered form of a message, with http/https URLs turned into links. The
-   * template binds to this, so the result is cached per message text: otherwise
-   * every change detection cycle re-escapes and re-sanitises every message on
-   * screen and hands the binding a fresh object, repainting the whole log.
+   * Rendered form of a message, cached by message text so change detection
+   * does not re-parse and re-sanitise every visible message on every cycle.
    */
   formatMessage(content?: string): SafeHtml {
     if (!content) {
       return '';
     }
+
     const cached = this.formattedMessages.get(content);
     if (cached !== undefined) {
       return cached;
     }
-    const formatted = this.linkifyMessage(content);
+
+    const cleanHtml = renderChatMarkdown(content);
+    const formatted = this.sanitizer.bypassSecurityTrustHtml(cleanHtml);
     this.formattedMessages.set(content, formatted);
     return formatted;
-  }
-
-  private linkifyMessage(content: string): SafeHtml {
-    // Match http/https URLs, then strip common trailing punctuation
-    // that is usually not part of the URL (e.g. periods at end of sentences).
-    const urlRegex = /(https?:\/\/[^\s]+)/g;
-
-    let html = '';
-    let lastIndex = 0;
-
-    for (const match of content.matchAll(urlRegex)) {
-      const originalUrl = match[0];
-      const index = match.index ?? 0;
-
-      // Strip trailing punctuation that is almost never part of a URL
-      const url = originalUrl.replace(/[.,;:!?)]+$/, '');
-      const trailing = originalUrl.slice(url.length);
-
-      // Append escaped text before this URL
-      html += this.escapeHtml(content.substring(lastIndex, index));
-
-      // Build the anchor — escape the URL in both href and display text
-      const safeUrl = this.escapeHtml(url);
-      html += `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeUrl}</a>${this.escapeHtml(trailing)}`;
-
-      // Advance past the original match length
-      lastIndex = index + originalUrl.length;
-    }
-
-    html += this.escapeHtml(content.substring(lastIndex));
-
-    // DOMPurify strips target by default — allow it so links open in a new tab
-    const cleanHtml = DOMPurify.sanitize(html, {
-      ADD_ATTR: ['target'],
-    });
-
-    return this.sanitizer.bypassSecurityTrustHtml(cleanHtml);
   }
 
   private parseClientTimestamp(timestamp: string | undefined): string | null {


### PR DESCRIPTION
## Summary
- render private and group chat messages as Markdown using `marked`
- sanitize rendered HTML with `DOMPurify` after parsing
- add styling for lists, blockquotes, inline code, and fenced code blocks
- add tests covering Markdown rendering and XSS sanitization

Closes #294