### PR TITLE
Feature issue#303

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -38,7 +38,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "1.5MB",
-                  "maximumError": "2MB"
+                  "maximumError": "2.5MB"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@stomp/stompjs": "^7.1.1",
         "@tailwindcss/postcss": "^4.1.10",
         "dompurify": "^3.4.11",
+        "emojilib": "^4.0.3",
         "marked": "^18.0.6",
         "ngx-toastr": "^19.1.0",
         "postcss": "^8.5.6",
@@ -29,6 +30,7 @@
         "sockjs-client": "^1.6.1",
         "tailwindcss": "^4.1.10",
         "tslib": "^2.3.0",
+        "unicode-emoji-json": "^0.9.0",
         "zone.js": "~0.15.0"
       },
       "devDependencies": {
@@ -8357,6 +8359,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emojilib": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-4.0.3.tgz",
+      "integrity": "sha512-KbWiYre9aRSaPbHrHZIz9zmoM+21LAsK1VFJtnTh1VCtWE/rNMDviGhQTmselFl95dhqtGlY22iH0leG5BuW0g==",
+      "license": "MIT"
+    },
     "node_modules/emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -15476,6 +15484,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unicode-emoji-json": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-json/-/unicode-emoji-json-0.9.0.tgz",
+      "integrity": "sha512-HdrQW/7SdbXUsTd8uTATv7LvQJkCSgbAgRCDCtOhQ6xn3EAx+xZHQtRniOXWJK3ywIqPegkNhP4U4EbuFsiQng==",
+      "license": "MIT"
     },
     "node_modules/unicode-match-property-ecmascript": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@stomp/stompjs": "^7.1.1",
     "@tailwindcss/postcss": "^4.1.10",
     "dompurify": "^3.4.11",
+    "emojilib": "^4.0.3",
     "marked": "^18.0.6",
     "ngx-toastr": "^19.1.0",
     "postcss": "^8.5.6",
@@ -34,6 +35,7 @@
     "sockjs-client": "^1.6.1",
     "tailwindcss": "^4.1.10",
     "tslib": "^2.3.0",
+    "unicode-emoji-json": "^0.9.0",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {

--- a/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-data.spec.ts
+++ b/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-data.spec.ts
@@ -1,0 +1,40 @@
+import { EMOJI_CATEGORIES, EMOJI_LIST } from './emoji-data';
+
+describe('emoji-data', () => {
+  it('exposes exactly the 8 categories required by the ticket', () => {
+    const ids = EMOJI_CATEGORIES.map((c) => c.id);
+    expect(ids).toEqual([
+      'smileys',
+      'people',
+      'nature',
+      'food',
+      'activities',
+      'objects',
+      'symbols',
+      'flags',
+    ]);
+    expect(new Set(ids).size).toBe(ids.length); // no duplicate category ids
+  });
+
+  it('builds a non-empty emoji list', () => {
+    expect(EMOJI_LIST.length).toBeGreaterThan(0);
+  });
+
+  it('assigns every emoji a known category', () => {
+    const validCategories = new Set(EMOJI_CATEGORIES.map((c) => c.id));
+    expect(EMOJI_LIST.every((e) => validCategories.has(e.category))).toBe(true);
+  });
+
+  it('gives every emoji a non-empty character and name', () => {
+    expect(EMOJI_LIST.every((e) => !!e.char && !!e.name)).toBe(true);
+  });
+
+  it('has no duplicate emoji characters', () => {
+    const chars = EMOJI_LIST.map((e) => e.char);
+    expect(new Set(chars).size).toBe(chars.length);
+  });
+
+  it('always gives every emoji a keywords array, even when emojilib has no entry', () => {
+    expect(EMOJI_LIST.every((e) => Array.isArray(e.keywords))).toBe(true);
+  });
+});

--- a/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-data.ts
+++ b/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-data.ts
@@ -1,0 +1,86 @@
+import rawEmojiData from 'unicode-emoji-json/data-by-group.json';
+import emojiKeywords from 'emojilib';
+
+export type EmojiCategoryId =
+  | 'smileys'
+  | 'people'
+  | 'nature'
+  | 'food'
+  | 'activities'
+  | 'objects'
+  | 'symbols'
+  | 'flags';
+
+export interface EmojiEntry {
+  char: string;
+  name: string;
+  keywords: string[];
+  category: EmojiCategoryId;
+}
+
+export interface EmojiCategory {
+  id: EmojiCategoryId;
+  label: string;
+  icon: string;
+}
+
+export const EMOJI_CATEGORIES: EmojiCategory[] = [
+  { id: 'smileys', label: 'Smileys', icon: '😀' },
+  { id: 'people', label: 'People', icon: '🙌' },
+  { id: 'nature', label: 'Nature', icon: '🌿' },
+  { id: 'food', label: 'Food', icon: '🍔' },
+  { id: 'activities', label: 'Activities', icon: '⚽' },
+  { id: 'objects', label: 'Objects', icon: '💡' },
+  { id: 'symbols', label: 'Symbols', icon: '❤️' },
+  { id: 'flags', label: 'Flags', icon: '🏳️' },
+];
+
+const GROUP_TO_CATEGORY: Record<string, EmojiCategoryId> = {
+  'Smileys & Emotion': 'smileys',
+  'People & Body': 'people',
+  'Animals & Nature': 'nature',
+  'Food & Drink': 'food',
+  'Travel & Places': 'objects',
+  Activities: 'activities',
+  Objects: 'objects',
+  Symbols: 'symbols',
+  Flags: 'flags',
+};
+
+interface RawEmoji {
+  emoji: string;
+  name: string;
+}
+
+interface RawEmojiGroup {
+  name: string;
+  slug: string;
+  emojis: RawEmoji[];
+}
+
+function buildEmojiList(): EmojiEntry[] {
+  const entries: EmojiEntry[] = [];
+  const groups = rawEmojiData as RawEmojiGroup[];
+  const keywords = emojiKeywords as Record<string, string[]>;
+
+  for (const group of groups) {
+    const category = GROUP_TO_CATEGORY[group.name];
+
+    if (!category) {
+      continue;
+    }
+
+    for (const emoji of group.emojis) {
+      entries.push({
+        char: emoji.emoji,
+        name: emoji.name,
+        keywords: keywords[emoji.emoji] ?? [],
+        category,
+      });
+    }
+  }
+
+  return entries;
+}
+
+export const EMOJI_LIST: EmojiEntry[] = buildEmojiList();

--- a/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.html
+++ b/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.html
@@ -20,7 +20,9 @@
       (click)="selectCategory('recent')"
       aria-label="Recently used"
       title="Recently used"
-    >🕓</button>
+    >
+      🕓
+    </button>
     <button
       *ngFor="let category of categories"
       type="button"
@@ -29,7 +31,9 @@
       (click)="selectCategory(category.id)"
       [attr.aria-label]="category.label"
       [title]="category.label"
-    >{{ category.icon }}</button>
+    >
+      {{ category.icon }}
+    </button>
   </div>
 
   <div class="emoji-picker-grid" role="listbox" aria-label="Emoji results">
@@ -42,8 +46,12 @@
       (keydown)="onGridKeydown($event, i)"
       [attr.aria-label]="emoji.name"
       [title]="emoji.name"
-    >{{ emoji.char }}</button>
+    >
+      {{ emoji.char }}
+    </button>
 
-    <div *ngIf="!visibleEmojis.length" class="emoji-picker-empty">No emoji found</div>
+    <div *ngIf="!visibleEmojis.length" class="emoji-picker-empty">
+      No emoji found
+    </div>
   </div>
 </div>

--- a/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.html
+++ b/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.html
@@ -1,0 +1,49 @@
+<div class="emoji-picker" role="dialog" aria-label="Emoji picker">
+  <div class="emoji-picker-search">
+    <i class="pi pi-search"></i>
+    <input
+      #searchInput
+      type="text"
+      [(ngModel)]="searchQuery"
+      placeholder="Search emoji"
+      aria-label="Search emoji"
+      autocomplete="off"
+    />
+  </div>
+
+  <div class="emoji-picker-tabs" *ngIf="!searchQuery.trim()" role="tablist">
+    <button
+      *ngIf="recents.length"
+      type="button"
+      class="emoji-picker-tab"
+      [class.is-active]="activeCategory === 'recent'"
+      (click)="selectCategory('recent')"
+      aria-label="Recently used"
+      title="Recently used"
+    >🕓</button>
+    <button
+      *ngFor="let category of categories"
+      type="button"
+      class="emoji-picker-tab"
+      [class.is-active]="activeCategory === category.id"
+      (click)="selectCategory(category.id)"
+      [attr.aria-label]="category.label"
+      [title]="category.label"
+    >{{ category.icon }}</button>
+  </div>
+
+  <div class="emoji-picker-grid" role="listbox" aria-label="Emoji results">
+    <button
+      #emojiButton
+      *ngFor="let emoji of visibleEmojis; let i = index"
+      type="button"
+      class="emoji-picker-option"
+      (click)="select(emoji)"
+      (keydown)="onGridKeydown($event, i)"
+      [attr.aria-label]="emoji.name"
+      [title]="emoji.name"
+    >{{ emoji.char }}</button>
+
+    <div *ngIf="!visibleEmojis.length" class="emoji-picker-empty">No emoji found</div>
+  </div>
+</div>

--- a/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.scss
+++ b/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.scss
@@ -1,0 +1,25 @@
+.emoji-picker { display: flex; flex-direction: column; width: 320px; max-height: 360px; }
+
+.emoji-picker-search {
+  display: flex; align-items: center; gap: 0.5rem;
+  padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--surface-border, #e5e7eb);
+  input { flex: 1; border: none; outline: none; background: transparent; font-size: 0.875rem; color: var(--text-color); }
+}
+
+.emoji-picker-tabs { display: flex; overflow-x: auto; border-bottom: 1px solid var(--surface-border, #e5e7eb); }
+
+.emoji-picker-tab {
+  flex: 0 0 auto; padding: 0.4rem 0.6rem; border: none; background: transparent;
+  font-size: 1rem; cursor: pointer; opacity: 0.6;
+  &.is-active { opacity: 1; border-bottom: 2px solid var(--primary-color); }
+}
+
+.emoji-picker-grid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 0.15rem; padding: 0.5rem; overflow-y: auto; }
+
+.emoji-picker-option {
+  border: none; background: transparent; font-size: 1.25rem; line-height: 1;
+  padding: 0.35rem; border-radius: 6px; cursor: pointer;
+  &:hover, &:focus-visible { background: var(--surface-c, #f3f4f6); outline: none; }
+}
+
+.emoji-picker-empty { grid-column: 1 / -1; text-align: center; font-size: 0.8rem; color: var(--text-color-secondary); padding: 1rem 0; }

--- a/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.scss
+++ b/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.scss
@@ -1,25 +1,138 @@
-.emoji-picker { display: flex; flex-direction: column; width: 320px; max-height: 360px; }
+.emoji-picker {
+  display: flex;
+  flex-direction: column;
+
+  width: 320px;
+  max-width: 100%;
+  height: 360px;
+  max-height: 360px;
+
+  box-sizing: border-box;
+  overflow: hidden;
+}
 
 .emoji-picker-search {
-  display: flex; align-items: center; gap: 0.5rem;
-  padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--surface-border, #e5e7eb);
-  input { flex: 1; border: none; outline: none; background: transparent; font-size: 0.875rem; color: var(--text-color); }
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  flex: 0 0 auto;
+
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--surface-border, #e5e7eb);
+
+  i {
+    flex: 0 0 auto;
+  }
+
+  input {
+    min-width: 0;
+    width: 100%;
+
+    border: none;
+    outline: none;
+    background: transparent;
+
+    font-size: 0.875rem;
+    color: var(--text-color);
+  }
 }
 
-.emoji-picker-tabs { display: flex; overflow-x: auto; border-bottom: 1px solid var(--surface-border, #e5e7eb); }
+.emoji-picker-tabs {
+  display: flex;
+  align-items: center;
+
+  flex: 0 0 auto;
+  width: 100%;
+  min-width: 0;
+
+  overflow: hidden;
+
+  border-bottom: 1px solid var(--surface-border, #e5e7eb);
+}
 
 .emoji-picker-tab {
-  flex: 0 0 auto; padding: 0.4rem 0.6rem; border: none; background: transparent;
-  font-size: 1rem; cursor: pointer; opacity: 0.6;
-  &.is-active { opacity: 1; border-bottom: 2px solid var(--primary-color); }
+  flex: 1 1 0;
+  min-width: 0;
+
+  padding: 0.4rem 0.15rem;
+
+  border: none;
+  background: transparent;
+
+  font-size: 1rem;
+  line-height: 1;
+
+  cursor: pointer;
+  opacity: 0.6;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    opacity: 0.9;
+    background: var(--surface-c, #f3f4f6);
+  }
+
+  &.is-active {
+    opacity: 1;
+    border-bottom: 2px solid var(--primary-color);
+  }
 }
 
-.emoji-picker-grid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 0.15rem; padding: 0.5rem; overflow-y: auto; }
+.emoji-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 0.15rem;
+
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+
+  flex: 1 1 auto;
+
+  padding: 0.5rem;
+  box-sizing: border-box;
+
+  overflow-x: hidden;
+  overflow-y: auto;
+}
 
 .emoji-picker-option {
-  border: none; background: transparent; font-size: 1.25rem; line-height: 1;
-  padding: 0.35rem; border-radius: 6px; cursor: pointer;
-  &:hover, &:focus-visible { background: var(--surface-c, #f3f4f6); outline: none; }
+  width: 100%;
+  min-width: 0;
+  aspect-ratio: 1;
+
+  border: none;
+  background: transparent;
+
+  font-size: 1.25rem;
+  line-height: 1;
+
+  padding: 0.35rem;
+  border-radius: 6px;
+
+  cursor: pointer;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--surface-c, #f3f4f6);
+    outline: none;
+  }
 }
 
-.emoji-picker-empty { grid-column: 1 / -1; text-align: center; font-size: 0.8rem; color: var(--text-color-secondary); padding: 1rem 0; }
+.emoji-picker-empty {
+  grid-column: 1 / -1;
+
+  text-align: center;
+  font-size: 0.8rem;
+
+  color: var(--text-color-secondary);
+
+  padding: 1rem 0;
+}

--- a/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.spec.ts
+++ b/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.spec.ts
@@ -1,0 +1,260 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { EmojiPickerComponent } from './emoji-picker.component';
+import { EMOJI_LIST } from './emoji-data';
+
+describe('EmojiPickerComponent', () => {
+  let fixture: ComponentFixture<EmojiPickerComponent>;
+  let component: EmojiPickerComponent;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    await TestBed.configureTestingModule({
+      imports: [EmojiPickerComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmojiPickerComponent);
+    component = fixture.componentInstance;
+    component.storageKey = 'alice';
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('initial state', () => {
+    it('defaults to the smileys category when there are no recents', () => {
+      expect(component.activeCategory).toBe('smileys');
+      expect(component.visibleEmojis).toEqual(
+        EMOJI_LIST.filter((e) => e.category === 'smileys'),
+      );
+    });
+
+    it('focuses the search input on init', async () => {
+      await fixture.whenStable();
+      const searchInput = fixture.debugElement.query(
+        By.css('input'),
+      ).nativeElement;
+      expect(document.activeElement).toBe(searchInput);
+    });
+  });
+
+  describe('search', () => {
+    it('filters by name (case-insensitive)', () => {
+      component.searchQuery = 'GRINNING';
+      fixture.detectChanges();
+
+      expect(component.visibleEmojis.length).toBeGreaterThan(0);
+      expect(
+        component.visibleEmojis.every(
+          (e) =>
+            e.name.toLowerCase().includes('grinning') ||
+            e.keywords.some((k) => k.toLowerCase().includes('grinning')),
+        ),
+      ).toBe(true);
+      expect(
+        component.visibleEmojis.some((e) =>
+          e.name.toLowerCase().includes('grinning'),
+        ),
+      ).toBe(true);
+    });
+
+    it('falls back to keyword matches when the name does not match', () => {
+      const target = EMOJI_LIST.find((e) => e.keywords.length > 0);
+      if (!target) {
+        return; // dataset provided no keywords in this environment
+      }
+      component.searchQuery = target.keywords[0];
+      fixture.detectChanges();
+      expect(component.visibleEmojis).toContain(target);
+    });
+
+    it('shows the empty state when nothing matches', () => {
+      component.searchQuery = 'zzzznomatchzzzz';
+      fixture.detectChanges();
+      expect(component.visibleEmojis.length).toBe(0);
+      expect(
+        fixture.debugElement.query(By.css('.emoji-picker-empty')),
+      ).toBeTruthy();
+    });
+
+    it('hides the category tabs while a search is active', () => {
+      component.searchQuery = 'face';
+      fixture.detectChanges();
+      expect(
+        fixture.debugElement.query(By.css('.emoji-picker-tabs')),
+      ).toBeFalsy();
+    });
+  });
+
+  describe('category selection', () => {
+    it('switches the active category and clears any search query', () => {
+      component.searchQuery = 'face';
+      component.selectCategory('food');
+      expect(component.activeCategory).toBe('food');
+      expect(component.searchQuery).toBe('');
+    });
+
+    it('shows only recents when the recent pseudo-category is active', () => {
+      const emoji = EMOJI_LIST[0];
+      component.select(emoji);
+      component.selectCategory('recent');
+      expect(component.visibleEmojis).toEqual([emoji]);
+    });
+  });
+
+  describe('selecting an emoji', () => {
+    it('emits the selected character', () => {
+      const emitSpy = spyOn(component.emojiSelected, 'emit');
+      const emoji = EMOJI_LIST[0];
+      component.select(emoji);
+      expect(emitSpy).toHaveBeenCalledWith(emoji.char);
+    });
+
+    it('adds the emoji to recents, most-recent first', () => {
+      const [first, second] = EMOJI_LIST;
+      component.select(first);
+      component.select(second);
+      expect(component.recents[0]).toEqual(second);
+      expect(component.recents[1]).toEqual(first);
+    });
+
+    it('de-duplicates recents, moving a re-selected emoji to the front', () => {
+      const [first, second] = EMOJI_LIST;
+      component.select(first);
+      component.select(second);
+      component.select(first);
+      expect(component.recents[0]).toEqual(first);
+      expect(
+        component.recents.filter((e) => e.char === first.char).length,
+      ).toBe(1);
+    });
+
+    it('caps recents at 24 entries', () => {
+      EMOJI_LIST.slice(0, 30).forEach((e) => component.select(e));
+      expect(component.recents.length).toBe(24);
+    });
+
+    it('persists recents to localStorage under a key namespaced by storageKey', () => {
+      const emoji = EMOJI_LIST[0];
+      component.select(emoji);
+      const raw = localStorage.getItem('chat.emojiPicker.recents.alice');
+      expect(raw).toBe(JSON.stringify([emoji.char]));
+    });
+
+    it('does not throw if localStorage.setItem fails', () => {
+      spyOn(localStorage, 'setItem').and.throwError('quota exceeded');
+      expect(() => component.select(EMOJI_LIST[0])).not.toThrow();
+    });
+  });
+
+  describe('loading recents on init', () => {
+    it('restores recents from localStorage and switches to the recent tab', () => {
+      const [first, second] = EMOJI_LIST;
+      localStorage.setItem(
+        'chat.emojiPicker.recents.bob',
+        JSON.stringify([second.char, first.char]),
+      );
+
+      const bobFixture = TestBed.createComponent(EmojiPickerComponent);
+      bobFixture.componentInstance.storageKey = 'bob';
+      bobFixture.detectChanges();
+
+      expect(bobFixture.componentInstance.activeCategory).toBe('recent');
+      expect(bobFixture.componentInstance.recents).toEqual([second, first]);
+    });
+
+    it('falls back to an empty list on malformed JSON', () => {
+      localStorage.setItem('chat.emojiPicker.recents.corrupt', '{not json');
+
+      const corruptFixture = TestBed.createComponent(EmojiPickerComponent);
+      corruptFixture.componentInstance.storageKey = 'corrupt';
+      expect(() => corruptFixture.detectChanges()).not.toThrow();
+      expect(corruptFixture.componentInstance.recents).toEqual([]);
+      expect(corruptFixture.componentInstance.activeCategory).toBe('smileys');
+    });
+
+    it('drops stored characters that no longer resolve to a known emoji', () => {
+      localStorage.setItem(
+        'chat.emojiPicker.recents.stale',
+        JSON.stringify(['not-a-real-emoji', EMOJI_LIST[0].char]),
+      );
+
+      const staleFixture = TestBed.createComponent(EmojiPickerComponent);
+      staleFixture.componentInstance.storageKey = 'stale';
+      staleFixture.detectChanges();
+
+      expect(staleFixture.componentInstance.recents).toEqual([EMOJI_LIST[0]]);
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    function buttons(): HTMLButtonElement[] {
+      return fixture.debugElement
+        .queryAll(By.css('.emoji-picker-option'))
+        .map((de) => de.nativeElement as HTMLButtonElement);
+    }
+
+    it('moves focus right/left with ArrowRight/ArrowLeft', () => {
+      const els = buttons();
+      els[0].focus();
+      component.onGridKeydown(
+        new KeyboardEvent('keydown', { key: 'ArrowRight' }),
+        0,
+      );
+      expect(document.activeElement).toBe(els[1]);
+
+      component.onGridKeydown(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft' }),
+        1,
+      );
+      expect(document.activeElement).toBe(els[0]);
+    });
+
+    it('moves focus by a full row with ArrowDown/ArrowUp', () => {
+      const els = buttons();
+      component.onGridKeydown(
+        new KeyboardEvent('keydown', { key: 'ArrowDown' }),
+        0,
+      );
+      expect(document.activeElement).toBe(els[8]); // GRID_COLUMNS = 8
+
+      component.onGridKeydown(
+        new KeyboardEvent('keydown', { key: 'ArrowUp' }),
+        8,
+      );
+      expect(document.activeElement).toBe(els[0]);
+    });
+
+    it('clamps at the first and last button instead of wrapping', () => {
+      const els = buttons();
+      component.onGridKeydown(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft' }),
+        0,
+      );
+      expect(document.activeElement).toBe(els[0]);
+
+      const lastIndex = els.length - 1;
+      component.onGridKeydown(
+        new KeyboardEvent('keydown', { key: 'ArrowRight' }),
+        lastIndex,
+      );
+      expect(document.activeElement).toBe(els[lastIndex]);
+    });
+
+    it('ignores unrelated keys and does not call preventDefault', () => {
+      const els = buttons();
+      els[0].focus();
+      const event = new KeyboardEvent('keydown', { key: 'Enter' });
+      const preventSpy = spyOn(event, 'preventDefault');
+      component.onGridKeydown(event, 0);
+      expect(preventSpy).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(els[0]);
+    });
+  });
+});

--- a/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.ts
@@ -1,10 +1,22 @@
 import { CommonModule } from '@angular/common';
 import {
-  Component, ElementRef, EventEmitter, Input, OnInit,
-  Output, ViewChild, ViewChildren, QueryList,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewChild,
+  ViewChildren,
+  QueryList,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { EMOJI_CATEGORIES, EMOJI_LIST, EmojiCategoryId, EmojiEntry } from './emoji-data';
+import {
+  EMOJI_CATEGORIES,
+  EMOJI_LIST,
+  EmojiCategoryId,
+  EmojiEntry,
+} from './emoji-data';
 
 const RECENTS_LIMIT = 24;
 const RECENTS_STORAGE_PREFIX = 'chat.emojiPicker.recents.';
@@ -23,7 +35,9 @@ export class EmojiPickerComponent implements OnInit {
   @Output() emojiSelected = new EventEmitter<string>();
 
   @ViewChild('searchInput') searchInputRef?: ElementRef<HTMLInputElement>;
-  @ViewChildren('emojiButton') emojiButtons!: QueryList<ElementRef<HTMLButtonElement>>;
+  @ViewChildren('emojiButton') emojiButtons!: QueryList<
+    ElementRef<HTMLButtonElement>
+  >;
 
   readonly categories = EMOJI_CATEGORIES;
 
@@ -73,11 +87,20 @@ export class EmojiPickerComponent implements OnInit {
 
     let nextIndex = index;
     switch (event.key) {
-      case 'ArrowRight': nextIndex = Math.min(index + 1, buttons.length - 1); break;
-      case 'ArrowLeft': nextIndex = Math.max(index - 1, 0); break;
-      case 'ArrowDown': nextIndex = Math.min(index + GRID_COLUMNS, buttons.length - 1); break;
-      case 'ArrowUp': nextIndex = Math.max(index - GRID_COLUMNS, 0); break;
-      default: return;
+      case 'ArrowRight':
+        nextIndex = Math.min(index + 1, buttons.length - 1);
+        break;
+      case 'ArrowLeft':
+        nextIndex = Math.max(index - 1, 0);
+        break;
+      case 'ArrowDown':
+        nextIndex = Math.min(index + GRID_COLUMNS, buttons.length - 1);
+        break;
+      case 'ArrowUp':
+        nextIndex = Math.max(index - GRID_COLUMNS, 0);
+        break;
+      default:
+        return;
     }
 
     event.preventDefault();
@@ -85,8 +108,10 @@ export class EmojiPickerComponent implements OnInit {
   }
 
   private pushRecent(emoji: EmojiEntry): void {
-    this.recents = [emoji, ...this.recents.filter((e) => e.char !== emoji.char)]
-      .slice(0, RECENTS_LIMIT);
+    this.recents = [
+      emoji,
+      ...this.recents.filter((e) => e.char !== emoji.char),
+    ].slice(0, RECENTS_LIMIT);
     this.saveRecents();
   }
 
@@ -95,7 +120,9 @@ export class EmojiPickerComponent implements OnInit {
       const raw = localStorage.getItem(this.recentsKey());
       if (!raw) return [];
       const chars: string[] = JSON.parse(raw);
-      return chars.map((c) => this.emojiByChar.get(c)).filter((e): e is EmojiEntry => !!e);
+      return chars
+        .map((c) => this.emojiByChar.get(c))
+        .filter((e): e is EmojiEntry => !!e);
     } catch {
       return [];
     }
@@ -103,7 +130,10 @@ export class EmojiPickerComponent implements OnInit {
 
   private saveRecents(): void {
     try {
-      localStorage.setItem(this.recentsKey(), JSON.stringify(this.recents.map((e) => e.char)));
+      localStorage.setItem(
+        this.recentsKey(),
+        JSON.stringify(this.recents.map((e) => e.char)),
+      );
     } catch {
       // localStorage can be unavailable (private browsing, quota) — recents
       // are a nice-to-have, so fail silently rather than break the picker.

--- a/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/emoji-picker/emoji-picker.component.ts
@@ -1,0 +1,116 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component, ElementRef, EventEmitter, Input, OnInit,
+  Output, ViewChild, ViewChildren, QueryList,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { EMOJI_CATEGORIES, EMOJI_LIST, EmojiCategoryId, EmojiEntry } from './emoji-data';
+
+const RECENTS_LIMIT = 24;
+const RECENTS_STORAGE_PREFIX = 'chat.emojiPicker.recents.';
+const GRID_COLUMNS = 8; // must match .emoji-picker-grid's grid-template-columns
+
+@Component({
+  selector: 'app-emoji-picker',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './emoji-picker.component.html',
+  styleUrls: ['./emoji-picker.component.scss'],
+})
+export class EmojiPickerComponent implements OnInit {
+  /** Namespaces the recents list in localStorage — pass the current username. */
+  @Input({ required: true }) storageKey!: string;
+  @Output() emojiSelected = new EventEmitter<string>();
+
+  @ViewChild('searchInput') searchInputRef?: ElementRef<HTMLInputElement>;
+  @ViewChildren('emojiButton') emojiButtons!: QueryList<ElementRef<HTMLButtonElement>>;
+
+  readonly categories = EMOJI_CATEGORIES;
+
+  searchQuery = '';
+  activeCategory: EmojiCategoryId | 'recent' = 'smileys';
+  recents: EmojiEntry[] = [];
+
+  private readonly emojiByChar = new Map(EMOJI_LIST.map((e) => [e.char, e]));
+
+  ngOnInit(): void {
+    this.recents = this.loadRecents();
+    if (this.recents.length) {
+      this.activeCategory = 'recent';
+    }
+    setTimeout(() => this.searchInputRef?.nativeElement.focus(), 0);
+  }
+
+  get visibleEmojis(): EmojiEntry[] {
+    const query = this.searchQuery.trim().toLowerCase();
+
+    if (query) {
+      return EMOJI_LIST.filter(
+        (e) =>
+          e.name.toLowerCase().includes(query) ||
+          e.keywords.some((k) => k.toLowerCase().includes(query)),
+      );
+    }
+
+    return this.activeCategory === 'recent'
+      ? this.recents
+      : EMOJI_LIST.filter((e) => e.category === this.activeCategory);
+  }
+
+  selectCategory(id: EmojiCategoryId | 'recent'): void {
+    this.activeCategory = id;
+    this.searchQuery = '';
+  }
+
+  select(emoji: EmojiEntry): void {
+    this.pushRecent(emoji);
+    this.emojiSelected.emit(emoji.char);
+  }
+
+  onGridKeydown(event: KeyboardEvent, index: number): void {
+    const buttons = this.emojiButtons.toArray();
+    if (!buttons.length) return;
+
+    let nextIndex = index;
+    switch (event.key) {
+      case 'ArrowRight': nextIndex = Math.min(index + 1, buttons.length - 1); break;
+      case 'ArrowLeft': nextIndex = Math.max(index - 1, 0); break;
+      case 'ArrowDown': nextIndex = Math.min(index + GRID_COLUMNS, buttons.length - 1); break;
+      case 'ArrowUp': nextIndex = Math.max(index - GRID_COLUMNS, 0); break;
+      default: return;
+    }
+
+    event.preventDefault();
+    buttons[nextIndex].nativeElement.focus();
+  }
+
+  private pushRecent(emoji: EmojiEntry): void {
+    this.recents = [emoji, ...this.recents.filter((e) => e.char !== emoji.char)]
+      .slice(0, RECENTS_LIMIT);
+    this.saveRecents();
+  }
+
+  private loadRecents(): EmojiEntry[] {
+    try {
+      const raw = localStorage.getItem(this.recentsKey());
+      if (!raw) return [];
+      const chars: string[] = JSON.parse(raw);
+      return chars.map((c) => this.emojiByChar.get(c)).filter((e): e is EmojiEntry => !!e);
+    } catch {
+      return [];
+    }
+  }
+
+  private saveRecents(): void {
+    try {
+      localStorage.setItem(this.recentsKey(), JSON.stringify(this.recents.map((e) => e.char)));
+    } catch {
+      // localStorage can be unavailable (private browsing, quota) — recents
+      // are a nice-to-have, so fail silently rather than break the picker.
+    }
+  }
+
+  private recentsKey(): string {
+    return `${RECENTS_STORAGE_PREFIX}${this.storageKey}`;
+  }
+}

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.html
@@ -202,21 +202,11 @@
         *ngIf="isEmojiPickerOpen || isStickerPickerOpen"
         class="reaction-popover"
       >
-        <div
+        <app-emoji-picker
           *ngIf="isEmojiPickerOpen"
-          class="emoji-grid"
-          aria-label="Emoji picker"
-        >
-          <button
-            *ngFor="let emoji of emojis"
-            type="button"
-            class="emoji-option"
-            (click)="insertEmoji(emoji)"
-            [attr.aria-label]="'Insert ' + emoji"
-          >
-            {{ emoji }}
-          </button>
-        </div>
+          [storageKey]="currentUsername || 'anonymous'"
+          (emojiSelected)="insertEmoji($event)"
+        ></app-emoji-picker>
 
         <div
           *ngIf="isStickerPickerOpen"
@@ -245,6 +235,7 @@
       >
         <i class="pi pi-face-smile"></i>
       </button>
+
       <button
         type="button"
         class="composer-tool-btn"
@@ -255,6 +246,7 @@
       >
         <i class="pi pi-image"></i>
       </button>
+
       <input
         #messageInput
         type="text"
@@ -266,6 +258,7 @@
         autocomplete="off"
         (focus)="closeReactionPickers()"
       />
+
       <button
         type="submit"
         class="send-btn px-5 bg-[var(--primary-color)] text-[var(--primary-color-text)] font-bold rounded-r-md transition hover:opacity-90"

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.scss
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.scss
@@ -271,39 +271,23 @@ button {
 .reaction-popover {
   position: absolute;
   left: 1rem;
-  right: 1rem;
+  right: auto;
   bottom: calc(100% + 0.55rem);
+
+  width: 320px;
+  max-width: calc(100% - 2rem);
+  box-sizing: border-box;
+
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   box-shadow: 0 14px 36px
     color-mix(in srgb, var(--color-shadow-md) 60%, transparent);
-  padding: 0.7rem;
+
+  padding: 0.4rem;
   z-index: 2;
-}
 
-.emoji-grid {
-  display: grid;
-  grid-template-columns: repeat(8, minmax(2rem, 1fr));
-  gap: 0.35rem;
-}
-
-.emoji-option {
-  aspect-ratio: 1;
-  border-radius: 0.5rem;
-  border: 1px solid transparent;
-  background: transparent;
-  font-size: 1.35rem;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  &:hover,
-  &:focus-visible {
-    border-color: var(--color-border-hover);
-    background: var(--color-surface-hover);
-  }
+  overflow: hidden;
 }
 
 .sticker-grid {
@@ -361,11 +345,10 @@ button {
 
   .reaction-popover {
     left: 0.75rem;
-    right: 0.75rem;
-  }
+    right: auto;
 
-  .emoji-grid {
-    grid-template-columns: repeat(4, minmax(2.4rem, 1fr));
+    width: 320px;
+    max-width: calc(100% - 1.5rem);
   }
 
   .sticker-grid {

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.spec.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.spec.ts
@@ -19,6 +19,7 @@ import { WebSocketService } from '../../services/web-socket.service';
 import { PrivateChatDialogComponent } from './private-chat-dialog.component';
 import { GroupService } from '../../services/group.service';
 import { UserService } from '../../services/user.service';
+import { By } from '@angular/platform-browser';
 
 describe('PrivateChatDialogComponent typing indicators', () => {
   let fixture: ComponentFixture<PrivateChatDialogComponent>;
@@ -528,5 +529,238 @@ describe('PrivateChatDialogComponent duplicate message detection', () => {
 
     expect(component.messages.length).toBe(1);
     discardPeriodicTasks();
+  }));
+});
+
+describe('PrivateChatDialogComponent emoji picker', () => {
+  let fixture: ComponentFixture<PrivateChatDialogComponent>;
+  let component: PrivateChatDialogComponent;
+
+  beforeEach(async () => {
+    const typingEvents = new Subject<TypingIndicatorDto>();
+    const wsService = jasmine.createSpyObj<WebSocketService>(
+      'WebSocketService',
+      [
+        'subscribeToPrivateMessages',
+        'subscribeToTypingIndicators',
+        'sendTypingIndicator',
+        'ensureConnected',
+        'sendPrivateMessage',
+        'sendGroupMessage',
+        'subscribeToGroupMessages',
+      ],
+    );
+    wsService.subscribeToPrivateMessages.and.returnValue(of<ChatMessageDto>());
+    wsService.subscribeToGroupMessages.and.returnValue(of<ChatMessageDto>());
+    wsService.subscribeToTypingIndicators.and.returnValue(
+      typingEvents.asObservable(),
+    );
+    wsService.sendTypingIndicator.and.returnValue(true);
+    wsService.ensureConnected.and.resolveTo(true);
+    wsService.sendPrivateMessage.and.returnValue(true);
+    wsService.sendGroupMessage.and.returnValue(true);
+
+    const chatService = jasmine.createSpyObj<PrivateChatService>(
+      'PrivateChatService',
+      ['getMessages', 'getDevices'],
+    );
+    chatService.getMessages.and.returnValue(of([]));
+    chatService.getDevices.and.returnValue(of<DeviceDto[]>([]));
+
+    const groupChatService = jasmine.createSpyObj<GroupChatService>(
+      'GroupChatService',
+      ['getMessages', 'getDevices'],
+    );
+    groupChatService.getMessages.and.returnValue(of([]));
+    groupChatService.getDevices.and.returnValue(of<DeviceDto[]>([]));
+
+    const e2eeService = jasmine.createSpyObj<E2eeService>('E2eeService', [
+      'ensureDeviceRegistered',
+      'encryptForDevices',
+      'decryptPayload',
+    ]);
+    e2eeService.ensureDeviceRegistered.and.resolveTo();
+
+    const toast = jasmine.createSpyObj<UiToastService>('UiToastService', [
+      'error',
+      'warn',
+    ]);
+
+    const groupService = jasmine.createSpyObj<GroupService>('GroupService', [
+      'getGroupDetails',
+    ]);
+    const userService = jasmine.createSpyObj<UserService>('UserService', [
+      'getProfilePictureUrl',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [PrivateChatDialogComponent],
+      providers: [
+        { provide: WebSocketService, useValue: wsService },
+        { provide: PrivateChatService, useValue: chatService },
+        { provide: GroupChatService, useValue: groupChatService },
+        { provide: E2eeService, useValue: e2eeService },
+        { provide: UiToastService, useValue: toast },
+        { provide: GroupService, useValue: groupService },
+        { provide: UserService, useValue: userService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PrivateChatDialogComponent);
+    component = fixture.componentInstance;
+    component.username = 'bob';
+    component.currentUsername = 'alice';
+    component.privateChatId = 10;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('toggles the emoji picker open and closed', () => {
+    expect(component.isEmojiPickerOpen).toBe(false);
+
+    component.toggleEmojiPicker();
+    expect(component.isEmojiPickerOpen).toBe(true);
+
+    component.toggleEmojiPicker();
+    expect(component.isEmojiPickerOpen).toBe(false);
+  });
+
+  it('renders app-emoji-picker only while the picker is open', () => {
+    expect(fixture.debugElement.query(By.css('app-emoji-picker'))).toBeFalsy();
+
+    component.toggleEmojiPicker();
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('app-emoji-picker'))).toBeTruthy();
+  });
+
+  it('passes the current username as the storageKey to the emoji picker', () => {
+    component.toggleEmojiPicker();
+    fixture.detectChanges();
+
+    const picker = fixture.debugElement.query(By.css('app-emoji-picker'));
+    expect(picker.componentInstance.storageKey).toBe('alice');
+  });
+
+  describe('insertEmoji (caret-position insertion)', () => {
+    function setCaret(el: HTMLTextAreaElement, position: number): void {
+      el.setSelectionRange(position, position);
+    }
+
+    it('inserts the emoji at the caret position, splitting the surrounding text', fakeAsync(() => {
+      component.newMessage = 'hello world';
+      fixture.detectChanges();
+
+      const input = (component as any).messageInput
+        .nativeElement as HTMLTextAreaElement;
+      input.value = component.newMessage;
+      setCaret(input, 5); // right after "hello"
+
+      component.insertEmoji('😀');
+      tick();
+
+      expect(component.newMessage).toBe('hello😀 world');
+    }));
+
+    it('inserts at the very start when the caret is at position 0', fakeAsync(() => {
+      component.newMessage = 'world';
+      fixture.detectChanges();
+
+      const input = (component as any).messageInput
+        .nativeElement as HTMLTextAreaElement;
+      input.value = component.newMessage;
+      setCaret(input, 0);
+
+      component.insertEmoji('👍');
+      tick();
+
+      expect(component.newMessage).toBe('👍world');
+    }));
+
+    it('inserts at the end when the caret is at the end of the text', fakeAsync(() => {
+      component.newMessage = 'hello';
+      fixture.detectChanges();
+
+      const input = (component as any).messageInput
+        .nativeElement as HTMLTextAreaElement;
+      input.value = component.newMessage;
+      setCaret(input, input.value.length);
+
+      component.insertEmoji('🔥');
+      tick();
+
+      expect(component.newMessage).toBe('hello🔥');
+    }));
+
+    it('replaces a selected range rather than inserting alongside it', fakeAsync(() => {
+      component.newMessage = 'hello world';
+      fixture.detectChanges();
+
+      const input = (component as any).messageInput
+        .nativeElement as HTMLTextAreaElement;
+      input.value = component.newMessage;
+      input.setSelectionRange(0, 5); // select "hello"
+
+      component.insertEmoji('👋');
+      tick();
+
+      expect(component.newMessage).toBe('👋 world');
+    }));
+
+    it('refocuses the message input after inserting an emoji', fakeAsync(() => {
+      component.newMessage = 'hi';
+      fixture.detectChanges();
+
+      const input = (component as any).messageInput
+        .nativeElement as HTMLTextAreaElement;
+      input.value = component.newMessage;
+      setCaret(input, 2);
+
+      component.insertEmoji('🎉');
+      tick();
+
+      expect(document.activeElement).toBe(input);
+    }));
+
+    it('moves the caret to just after the inserted emoji', fakeAsync(() => {
+      component.newMessage = 'hi there';
+      fixture.detectChanges();
+
+      const input = (component as any).messageInput
+        .nativeElement as HTMLTextAreaElement;
+      input.value = component.newMessage;
+      setCaret(input, 2); // right after "hi"
+
+      component.insertEmoji('🎉');
+      tick();
+
+      const expectedCaret = 'hi🎉'.length;
+      expect(input.selectionStart).toBe(expectedCaret);
+      expect(input.selectionEnd).toBe(expectedCaret);
+    }));
+  });
+
+  it('wires the emoji picker output to insertEmoji', fakeAsync(() => {
+    component.newMessage = 'test';
+    fixture.detectChanges();
+
+    const input = (component as any).messageInput
+      .nativeElement as HTMLTextAreaElement;
+    input.value = component.newMessage;
+    input.setSelectionRange(4, 4);
+
+    const insertSpy = spyOn(component, 'insertEmoji').and.callThrough();
+
+    component.toggleEmojiPicker();
+    fixture.detectChanges();
+
+    const picker = fixture.debugElement.query(By.css('app-emoji-picker'));
+    picker.triggerEventHandler('emojiSelected', '😀');
+    tick();
+
+    expect(insertSpy).toHaveBeenCalledWith('😀');
   }));
 });

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -26,11 +26,7 @@ import { GroupService } from '../../services/group.service';
 import { UserService } from '../../services/user.service';
 import { GroupDto } from '../../models/dtos/GroupDto';
 import { UserDto } from '../../models/dtos/UserDto';
-import {
-  CHAT_STICKERS,
-  ChatSticker,
-  findChatSticker,
-} from './chat-reactions';
+import { CHAT_STICKERS, ChatSticker, findChatSticker } from './chat-reactions';
 
 import { EmojiPickerComponent } from './emoji-picker/emoji-picker.component';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';

--- a/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
+++ b/frontend/src/app/pages/private-chat-dialog/private-chat-dialog.component.ts
@@ -27,11 +27,12 @@ import { UserService } from '../../services/user.service';
 import { GroupDto } from '../../models/dtos/GroupDto';
 import { UserDto } from '../../models/dtos/UserDto';
 import {
-  CHAT_EMOJIS,
   CHAT_STICKERS,
   ChatSticker,
   findChatSticker,
 } from './chat-reactions';
+
+import { EmojiPickerComponent } from './emoji-picker/emoji-picker.component';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { renderChatMarkdown } from './chat-markdown';
 
@@ -80,7 +81,7 @@ type ParsedDecryptedMessageBody = {
 @Component({
   selector: 'app-private-chat-dialog',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, EmojiPickerComponent],
   templateUrl: './private-chat-dialog.component.html',
   styleUrls: ['./private-chat-dialog.component.scss'],
 })
@@ -119,7 +120,6 @@ export class PrivateChatDialogComponent
   matchedMessageIndexes: number[] = [];
   private matchedMessageIndexSet = new Set<number>();
   activeMatchPosition = -1;
-  readonly emojis = CHAT_EMOJIS;
   readonly stickers = CHAT_STICKERS;
   isEmojiPickerOpen = false;
   isStickerPickerOpen = false;


### PR DESCRIPTION
## Summary

- Added a reusable emoji picker component for private chat.
- Added emoji data with categories and `emojilib` keyword support.
- Added emoji search, category filtering, recently used emojis, and keyboard navigation.
- Integrated the new emoji picker into the private chat dialog.
- Preserved the existing caret-position emoji insertion behavior.
- Updated the picker styling to provide a compact layout without horizontal overflow.

## Linked issue

Closes #303

## How to test

1. Open a private chat.
2. Click the emoji button to open the emoji picker.
3. Verify emojis are displayed across the available categories.
4. Switch between emoji categories and verify the displayed emojis change.
5. Search for an emoji by name or keyword and verify the results.
6. Select emojis and verify they are added to the recently used section.
7. Refresh the page and verify recently used emojis are persisted.
8. Use keyboard navigation to navigate and select emojis.
9. Place the cursor at different positions in the message input and verify the selected emoji is inserted at the caret position.
10. Verify the existing sticker picker still works.
11. Verify the emoji picker layout has no unwanted horizontal scrolling.

## Notes / Risk

- No database migrations, feature flags, or rollout changes.
- Existing sticker functionality and message insertion logic are preserved.
- Emoji data is provided by `unicode-emoji-json` and keyword search uses `emojilib`.
