### PR TITLE
fix(auth): validate stored JWT server-side before allowing protected …

### DIFF
--- a/frontend/src/app/auth.guard.spec.ts
+++ b/frontend/src/app/auth.guard.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { authGuard } from './auth.guard';
+import { AuthService } from './services/auth.service';
+import { environment } from '../environments/environment';
+
+describe('authGuard', () => {
+  let httpMock: HttpTestingController;
+  let authService: AuthService;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        AuthService,
+        {
+          provide: Router,
+          useValue: { navigate: jasmine.createSpy('navigate') },
+        },
+      ],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+    authService = TestBed.inject(AuthService);
+    router = TestBed.inject(Router);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should deny access when no token exists', async () => {
+    const result = await TestBed.runInInjectionContext(() =>
+      authGuard({} as any, {} as any),
+    );
+    expect(result).toBe(false);
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+
+  it('should deny access when local token is expired', async () => {
+    const pastExp = Math.floor(Date.now() / 1000) - 3600;
+    const token = createJwt({ sub: 'user1', exp: pastExp });
+    authService.saveToken(token);
+
+    const result = await TestBed.runInInjectionContext(() =>
+      authGuard({} as any, {} as any),
+    );
+    expect(result).toBe(false);
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+
+  it('should allow access when local token is valid and server refresh succeeds', async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const oldToken = createJwt({ sub: 'user1', exp: futureExp });
+    const newToken = createJwt({ sub: 'user1', exp: futureExp + 7200 });
+    authService.saveToken(oldToken);
+
+    const guardPromise = TestBed.runInInjectionContext(() =>
+      authGuard({} as any, {} as any),
+    );
+
+    const req = httpMock.expectOne(`${environment.mainApiUrl}/auth/refresh`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ token: newToken });
+
+    const result = await guardPromise;
+    expect(result).toBe(true);
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should deny access when local token is valid but server rejects refresh (401)', async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const token = createJwt({ sub: 'user1', exp: futureExp });
+    authService.saveToken(token);
+
+    const guardPromise = TestBed.runInInjectionContext(() =>
+      authGuard({} as any, {} as any),
+    );
+
+    const req = httpMock.expectOne(`${environment.mainApiUrl}/auth/refresh`);
+    req.flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    const result = await guardPromise;
+    expect(result).toBe(false);
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+    expect(localStorage.getItem('token')).toBeNull();
+  });
+
+  it('should deny access on server error and redirect to login', async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const token = createJwt({ sub: 'user1', exp: futureExp });
+    authService.saveToken(token);
+
+    const guardPromise = TestBed.runInInjectionContext(() =>
+      authGuard({} as any, {} as any),
+    );
+
+    const req = httpMock.expectOne(`${environment.mainApiUrl}/auth/refresh`);
+    req.error(new ErrorEvent('Network error'));
+
+    const result = await guardPromise;
+    expect(result).toBe(false);
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+});
+
+function createJwt(payload: any): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payloadStr = btoa(JSON.stringify(payload));
+  const signature = 'dummy_signature';
+  return `${header}.${payloadStr}.${signature}`;
+}

--- a/frontend/src/app/auth.guard.ts
+++ b/frontend/src/app/auth.guard.ts
@@ -1,15 +1,24 @@
 import { CanActivateFn, Router } from '@angular/router';
 import { AuthService } from './services/auth.service';
 import { inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 
-export const authGuard: CanActivateFn = (_route, _state) => {
+export const authGuard: CanActivateFn = async (_route, _state) => {
   const authService = inject(AuthService);
   const router = inject(Router);
 
-  if (authService.isLoggedIn()) {
-    return true;
-  } else {
+  if (!authService.isLoggedInLocally()) {
     router.navigate(['/login']);
     return false;
   }
+
+  const isValidOnServer = await firstValueFrom(
+    authService.validateTokenWithServer(),
+  );
+  if (!isValidOnServer) {
+    router.navigate(['/login']);
+    return false;
+  }
+
+  return true;
 };

--- a/frontend/src/app/services/auth.service.spec.ts
+++ b/frontend/src/app/services/auth.service.spec.ts
@@ -1,0 +1,185 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { AuthService } from './auth.service';
+import { Router } from '@angular/router';
+import { environment } from '../../environments/environment';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+  let routerSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        AuthService,
+        {
+          provide: Router,
+          useValue: { navigate: jasmine.createSpy('navigate') },
+        },
+      ],
+    });
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+    routerSpy = spyOn(TestBed.inject(Router), 'navigate');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  describe('isLoggedInLocally()', () => {
+    it('should return false when no token exists', () => {
+      expect(service.isLoggedInLocally()).toBe(false);
+    });
+
+    it('should return false when token cannot be decoded', () => {
+      service.saveToken('invalid.token');
+      expect(service.isLoggedInLocally()).toBe(false);
+    });
+
+    it('should return true for token with no exp claim', () => {
+      const token =
+        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMSJ9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ';
+      service.saveToken(token);
+      expect(service.isLoggedInLocally()).toBe(true);
+    });
+
+    it('should return true for non-expired token with exp claim', () => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600; // 1 hour in future
+      const payload = { sub: 'user1', exp: futureExp };
+      const token = createJwt(payload);
+      service.saveToken(token);
+      expect(service.isLoggedInLocally()).toBe(true);
+    });
+
+    it('should return false for expired token', () => {
+      const pastExp = Math.floor(Date.now() / 1000) - 3600; // 1 hour in past
+      const payload = { sub: 'user1', exp: pastExp };
+      const token = createJwt(payload);
+      service.saveToken(token);
+      expect(service.isLoggedInLocally()).toBe(false);
+    });
+  });
+
+  describe('validateTokenWithServer()', () => {
+    it('should return false when no token exists locally', (done) => {
+      service.validateTokenWithServer().subscribe((result) => {
+        expect(result).toBe(false);
+        done();
+      });
+    });
+
+    it('should call /auth/refresh and update token on success', (done) => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const oldToken = createJwt({ sub: 'user1', exp: futureExp });
+      const newToken = createJwt({ sub: 'user1', exp: futureExp + 7200 });
+      service.saveToken(oldToken);
+
+      service.validateTokenWithServer().subscribe((result) => {
+        expect(result).toBe(true);
+        expect(service.getToken()).toBe(newToken);
+        done();
+      });
+
+      const req = httpMock.expectOne(`${environment.mainApiUrl}/auth/refresh`);
+      expect(req.request.method).toBe('POST');
+      req.flush({ token: newToken });
+    });
+
+    it('should clear auth state and return false when server responds with 401', (done) => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const token = createJwt({ sub: 'user1', exp: futureExp });
+      service.saveToken(token);
+      service.saveUsername('testuser');
+
+      service.validateTokenWithServer().subscribe((result) => {
+        expect(result).toBe(false);
+        expect(localStorage.getItem('token')).toBeNull();
+        expect(localStorage.getItem('username')).toBeNull();
+        done();
+      });
+
+      const req = httpMock.expectOne(`${environment.mainApiUrl}/auth/refresh`);
+      req.flush(null, { status: 401, statusText: 'Unauthorized' });
+    });
+
+    it('should clear auth state and return false when server responds with 403', (done) => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const token = createJwt({ sub: 'user1', exp: futureExp });
+      service.saveToken(token);
+      service.saveUsername('testuser');
+
+      service.validateTokenWithServer().subscribe((result) => {
+        expect(result).toBe(false);
+        expect(localStorage.getItem('token')).toBeNull();
+        expect(localStorage.getItem('username')).toBeNull();
+        done();
+      });
+
+      const req = httpMock.expectOne(`${environment.mainApiUrl}/auth/refresh`);
+      req.flush(null, { status: 403, statusText: 'Forbidden' });
+    });
+
+    it('should return false on network error', (done) => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const token = createJwt({ sub: 'user1', exp: futureExp });
+      service.saveToken(token);
+
+      service.validateTokenWithServer().subscribe((result) => {
+        expect(result).toBe(false);
+        done();
+      });
+
+      const req = httpMock.expectOne(`${environment.mainApiUrl}/auth/refresh`);
+      req.error(new ErrorEvent('Network error'));
+    });
+
+    it('should handle server 500 error gracefully (fail-closed)', (done) => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const token = createJwt({ sub: 'user1', exp: futureExp });
+      service.saveToken(token);
+
+      service.validateTokenWithServer().subscribe((result) => {
+        expect(result).toBe(false);
+        done();
+      });
+
+      const req = httpMock.expectOne(`${environment.mainApiUrl}/auth/refresh`);
+      req.flush(null, { status: 500, statusText: 'Internal Server Error' });
+    });
+  });
+
+  describe('Integration: locally valid token that is server-invalid (revoked)', () => {
+    it('should allow navigation locally but fail server validation on revoked token', (done) => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const token = createJwt({ sub: 'user1', exp: futureExp });
+      service.saveToken(token);
+
+      expect(service.isLoggedInLocally()).toBe(true);
+
+      service.validateTokenWithServer().subscribe((result) => {
+        expect(result).toBe(false);
+        expect(localStorage.getItem('token')).toBeNull();
+        done();
+      });
+
+      const req = httpMock.expectOne(`${environment.mainApiUrl}/auth/refresh`);
+      req.flush(null, { status: 401, statusText: 'Unauthorized' });
+    });
+  });
+});
+
+function createJwt(payload: any): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payloadStr = btoa(JSON.stringify(payload));
+  const signature = 'dummy_signature';
+  return `${header}.${payloadStr}.${signature}`;
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { finalize, map, Observable, tap } from 'rxjs';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { finalize, map, Observable, tap, catchError } from 'rxjs';
+import { of } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { Router } from '@angular/router';
 
@@ -58,23 +59,28 @@ export class AuthService {
     });
   }
 
-  saveToken(token: string): void {
-    localStorage.setItem('token', token);
+  validateTokenWithServer(): Observable<boolean> {
+    const token = this.getToken();
+    if (!token) {
+      return of(false);
+    }
+
+    return this.refresh().pipe(
+      tap((res) => {
+        this.saveToken(res.token);
+      }),
+      map(() => true),
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 401 || error.status === 403) {
+          this.clearAuthState();
+          return of(false);
+        }
+        return of(false);
+      }),
+    );
   }
 
-  saveUsername(username: string): void {
-    localStorage.setItem('username', username);
-  }
-
-  getToken(): string | null {
-    return localStorage.getItem('token') as string | null;
-  }
-
-  getUsername(): string | null {
-    return localStorage.getItem('username') as string | null;
-  }
-
-  isLoggedIn(): boolean {
+  isLoggedInLocally(): boolean {
     const token = localStorage.getItem('token');
     if (!token) {
       return false;
@@ -90,6 +96,31 @@ export class AuthService {
       return true;
     }
     return Date.now() < payload.exp * 1000;
+  }
+
+  isLoggedIn(): boolean {
+    return this.isLoggedInLocally();
+  }
+
+  private clearAuthState(): void {
+    localStorage.removeItem('token');
+    localStorage.removeItem('username');
+  }
+
+  saveToken(token: string): void {
+    localStorage.setItem('token', token);
+  }
+
+  saveUsername(username: string): void {
+    localStorage.setItem('username', username);
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem('token') as string | null;
+  }
+
+  getUsername(): string | null {
+    return localStorage.getItem('username') as string | null;
   }
 
   private decodeTokenPayload(token: string): { exp?: number } | null {


### PR DESCRIPTION
## Summary
Fixed authentication guard to validate sessions server-side instead of relying solely on locally-decoded JWT expiry. Frontend now checks with backend before allowing navigation to protected routes, ensuring revoked/invalidated sessions are properly rejected.

### Changes
- `AuthService.validateTokenWithServer()`: Calls `/auth/refresh` to validate session server-side
- `AuthService.isLoggedInLocally()`: Extracted local JWT check (fast, client-side only)
- `authGuard`: Made async; validates with server before allowing navigation
- Added tests covering locally-valid, server-revoked token scenario

## Linked issue
Closes #330 

## How to test
1. Login with credentials
2. Manually revoke the session:
   ```sql
   UPDATE refresh_token SET revoked = true WHERE user_id = <your_user_id>;
3. Try to navigate to a protected route (e.g., /dashboard)
4. Expected: Frontend allows local check to pass, backend rejects refresh, user redirected to login
5. Verify: localStorage is cleared after redirect

## Notes / Risk
No breaking changes to existing endpoints
Backward compatible: isLoggedIn() still returns local check only for other use cases
