### PR TITLE
Fix: add missing authorization checks in group access

### DIFF
--- a/backend/src/main/java/vaultWeb/controllers/GroupController.java
+++ b/backend/src/main/java/vaultWeb/controllers/GroupController.java
@@ -13,6 +13,7 @@ import vaultWeb.dtos.DeviceDto;
 import vaultWeb.dtos.GroupDto;
 import vaultWeb.dtos.GroupResponseDto;
 import vaultWeb.exceptions.UnauthorizedException;
+import vaultWeb.exceptions.notfound.GroupNotFoundException;
 import vaultWeb.exceptions.notfound.NotMemberException;
 import vaultWeb.models.ChatMessage;
 import vaultWeb.models.Group;
@@ -71,11 +72,17 @@ public class GroupController {
       responseCode = "401",
       description = "Unauthorized request. You must provide an authentication token.")
   @ApiResponse(responseCode = "404", description = "Group was not found.")
-  public ResponseEntity<GroupResponseDto> getGroupById(@PathVariable Long id) {
+  public ResponseEntity<GroupResponseDto> getGroupById(
+      @PathVariable Long id, Authentication authentication) {
     return groupService
         .getGroupById(id)
-        .map(GroupResponseDto::from)
-        .map(ResponseEntity::ok)
+        .map(
+            group -> {
+              if (!Boolean.TRUE.equals(group.getIsPublic())) {
+                getAuthenticatedGroupMember(id, authentication);
+              }
+              return ResponseEntity.ok(GroupResponseDto.from(group));
+            })
         .orElse(ResponseEntity.notFound().build());
   }
 
@@ -91,8 +98,19 @@ public class GroupController {
   @ApiResponse(
       responseCode = "401",
       description = "Unauthorized request. You must provide an authentication token.")
-  public ResponseEntity<List<User>> getGroupMembers(@PathVariable Long id) {
-    List<User> members = groupService.getMembers(id);
+  public ResponseEntity<List<User>> getGroupMembers(
+      @PathVariable Long id, Authentication authentication) {
+    Group group =
+        groupService
+            .getGroupById(id)
+            .orElseThrow(() -> new GroupNotFoundException("Group not found with id: " + id));
+
+    if (!Boolean.TRUE.equals(group.getIsPublic())) {
+      getAuthenticatedGroupMember(id, authentication);
+    }
+
+    List<User> members =
+        groupMemberRepository.findAllByGroup(group).stream().map(gm -> gm.getUser()).toList();
     return ResponseEntity.ok(members);
   }
 

--- a/backend/src/main/java/vaultWeb/exceptions/PrivateGroupJoinException.java
+++ b/backend/src/main/java/vaultWeb/exceptions/PrivateGroupJoinException.java
@@ -1,0 +1,18 @@
+package vaultWeb.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** Thrown when a user tries to self-join a private group. */
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class PrivateGroupJoinException extends RuntimeException {
+
+  /**
+   * Constructs a new PrivateGroupJoinException for a specific group.
+   *
+   * @param groupId the ID of the private group the user tried to join
+   */
+  public PrivateGroupJoinException(Long groupId) {
+    super("Cannot self-join private group with id: " + groupId);
+  }
+}

--- a/backend/src/main/java/vaultWeb/services/GroupService.java
+++ b/backend/src/main/java/vaultWeb/services/GroupService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import vaultWeb.dtos.GroupDto;
 import vaultWeb.exceptions.AlreadyMemberException;
 import vaultWeb.exceptions.LastAdminException;
+import vaultWeb.exceptions.PrivateGroupJoinException;
 import vaultWeb.exceptions.notfound.GroupNotFoundException;
 import vaultWeb.exceptions.notfound.NotMemberException;
 import vaultWeb.exceptions.notfound.UserNotFoundException;
@@ -104,6 +105,7 @@ public class GroupService {
    * @return the group the user joined.
    * @throws GroupNotFoundException if no group exists with the given ID.
    * @throws AlreadyMemberException if the user is already a member of the group.
+   * @throws PrivateGroupJoinException if the group is private.
    */
   public Group joinGroup(Long groupId, User currentUser) {
     Group group =
@@ -115,6 +117,10 @@ public class GroupService {
         groupMemberRepository.findByGroupAndUser(group, currentUser).isPresent();
     if (alreadyMember) {
       throw new AlreadyMemberException(groupId, currentUser.getId());
+    }
+
+    if (!Boolean.TRUE.equals(group.getIsPublic())) {
+      throw new PrivateGroupJoinException(groupId);
     }
 
     groupMemberRepository.save(new GroupMember(group, currentUser, Role.USER));

--- a/backend/src/test/java/vaultWeb/controllers/GroupControllerTest.java
+++ b/backend/src/test/java/vaultWeb/controllers/GroupControllerTest.java
@@ -121,31 +121,41 @@ class GroupControllerTest {
   @Test
   void shouldGetGroupByIdSuccessfully() {
     Group group = createTestGroup(1L, "Group 1");
+    Authentication authentication = mock(Authentication.class);
     when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
-    ResponseEntity<GroupResponseDto> response = groupController.getGroupById(1L);
+    ResponseEntity<GroupResponseDto> response = groupController.getGroupById(1L, authentication);
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(1L, response.getBody().getId());
     assertEquals("Group 1", response.getBody().getName());
     verify(groupService, times(1)).getGroupById(1L);
+    verify(groupMemberRepository, times(0)).findByGroupIdAndUserId(any(), any());
   }
 
   @Test
   void shouldReturnNotFound_WhenGroupDoesNotExist() {
     when(groupService.getGroupById(999L)).thenReturn(Optional.empty());
-    ResponseEntity<GroupResponseDto> response = groupController.getGroupById(999L);
+    ResponseEntity<GroupResponseDto> response = groupController.getGroupById(999L, null);
     assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     verify(groupService, times(1)).getGroupById(999L);
   }
 
   @Test
   void shouldGetGroupMembersSuccessfully() {
+    Group group = createTestGroup(1L, "Group 1");
     List<User> expectedMembers =
         List.of(createTestUser(1L, "User 1"), createTestUser(2L, "User 2"));
-    when(groupService.getMembers(1L)).thenReturn(expectedMembers);
-    ResponseEntity<List<User>> response = groupController.getGroupMembers(1L);
+    Authentication authentication = mock(Authentication.class);
+    GroupMember member1 = mock(GroupMember.class);
+    GroupMember member2 = mock(GroupMember.class);
+    when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
+    when(groupMemberRepository.findAllByGroup(group)).thenReturn(List.of(member1, member2));
+    when(member1.getUser()).thenReturn(expectedMembers.get(0));
+    when(member2.getUser()).thenReturn(expectedMembers.get(1));
+
+    ResponseEntity<List<User>> response = groupController.getGroupMembers(1L, authentication);
+
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(expectedMembers, response.getBody());
-    verify(groupService, times(1)).getMembers(1L);
   }
 
   @Test
@@ -223,7 +233,6 @@ class GroupControllerTest {
 
   @Test
   void shouldHandleEmptyGroupList() {
-
     when(groupService.getPublicGroups()).thenReturn(List.of());
     ResponseEntity<List<Group>> response = groupController.getGroups();
     assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -263,19 +272,21 @@ class GroupControllerTest {
 
   @Test
   void shouldHandleEmptyMemberList() {
-    when(groupService.getMembers(1L)).thenReturn(List.of());
-    ResponseEntity<List<User>> response = groupController.getGroupMembers(1L);
+    Group group = createTestGroup(1L, "Group 1");
+    Authentication authentication = mock(Authentication.class);
+    when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
+    when(groupMemberRepository.findAllByGroup(group)).thenReturn(List.of());
+    ResponseEntity<List<User>> response = groupController.getGroupMembers(1L, authentication);
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(List.of(), response.getBody());
-    verify(groupService, times(1)).getMembers(1L);
   }
 
   @Test
   void shouldFailGetMembers_WhenGroupNotFound() {
-    when(groupService.getMembers(999L))
-        .thenThrow(new GroupNotFoundException("Group not found with id: 999"));
-    assertThrows(GroupNotFoundException.class, () -> groupController.getGroupMembers(999L));
-    verify(groupService, times(1)).getMembers(999L);
+    when(groupService.getGroupById(999L)).thenReturn(Optional.empty());
+    assertThrows(
+        GroupNotFoundException.class, () -> groupController.getGroupMembers(999L, null));
+    verify(groupService, times(1)).getGroupById(999L);
   }
 
   @Test
@@ -286,6 +297,114 @@ class GroupControllerTest {
     assertThrows(
         GroupNotFoundException.class, () -> groupController.updateGroup(999L, testGroupDto));
     verify(groupService, times(1)).updateGroup(999L, testGroupDto);
+  }
+
+  @Test
+  void shouldGetPublicGroupById_ForAuthenticatedNonMember() {
+    Group group = createTestGroup(1L, "Group 1", true);
+    Authentication authentication = mock(Authentication.class);
+    when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
+
+    ResponseEntity<GroupResponseDto> response = groupController.getGroupById(1L, authentication);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(1L, response.getBody().getId());
+    assertEquals("Group 1", response.getBody().getName());
+    verify(groupMemberRepository, times(0)).findByGroupIdAndUserId(any(), any());
+  }
+
+  @Test
+  void shouldGetPrivateGroupById_WhenCallerIsMember() {
+    Group group = createTestGroup(1L, "Private Group", false);
+    Authentication authentication = mock(Authentication.class);
+    User user = createTestUser(5L, "Member");
+    when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
+    when(authService.getCurrentUser()).thenReturn(user);
+    when(groupMemberRepository.findByGroupIdAndUserId(1L, 5L))
+        .thenReturn(Optional.of(mock(GroupMember.class)));
+
+    ResponseEntity<GroupResponseDto> response = groupController.getGroupById(1L, authentication);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(1L, response.getBody().getId());
+  }
+
+  @Test
+  void shouldRejectGetPrivateGroupById_WhenCallerIsNotMember() {
+    Group group = createTestGroup(1L, "Private Group", false);
+    Authentication authentication = mock(Authentication.class);
+    User user = createTestUser(5L, "User 5");
+    when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
+    when(authService.getCurrentUser()).thenReturn(user);
+    when(groupMemberRepository.findByGroupIdAndUserId(1L, 5L)).thenReturn(Optional.empty());
+
+    assertThrows(NotMemberException.class, () -> groupController.getGroupById(1L, authentication));
+  }
+
+  @Test
+  void shouldRejectGetPrivateGroupById_WhenUnauthenticated() {
+    Group group = createTestGroup(1L, "Private Group", false);
+    when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
+
+    assertThrows(UnauthorizedException.class, () -> groupController.getGroupById(1L, null));
+  }
+
+  @Test
+  void shouldGetPublicGroupMembers_ForAuthenticatedNonMember() {
+    Group group = createTestGroup(1L, "Group 1", true);
+    List<User> expectedMembers = List.of(createTestUser(1L, "User 1"));
+    Authentication authentication = mock(Authentication.class);
+    GroupMember groupMember = mock(GroupMember.class);
+    when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
+    when(groupMember.getUser()).thenReturn(expectedMembers.get(0));
+    when(groupMemberRepository.findAllByGroup(group)).thenReturn(List.of(groupMember));
+
+    ResponseEntity<List<User>> response = groupController.getGroupMembers(1L, authentication);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(expectedMembers, response.getBody());
+    verify(groupMemberRepository, times(0)).findByGroupIdAndUserId(any(), any());
+  }
+
+  @Test
+  void shouldGetPrivateGroupMembers_WhenCallerIsMember() {
+    Group group = createTestGroup(1L, "Private Group", false);
+    List<User> expectedMembers = List.of(createTestUser(1L, "Member"));
+    Authentication authentication = mock(Authentication.class);
+    User currentUser = createTestUser(5L, "User 5");
+    GroupMember groupMember = mock(GroupMember.class);
+    when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
+    when(groupMember.getUser()).thenReturn(expectedMembers.get(0));
+    when(groupMemberRepository.findAllByGroup(group)).thenReturn(List.of(groupMember));
+    when(authService.getCurrentUser()).thenReturn(currentUser);
+    when(groupMemberRepository.findByGroupIdAndUserId(1L, 5L))
+        .thenReturn(Optional.of(mock(GroupMember.class)));
+
+    ResponseEntity<List<User>> response = groupController.getGroupMembers(1L, authentication);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(expectedMembers, response.getBody());
+  }
+
+  @Test
+  void shouldRejectGetPrivateGroupMembers_WhenCallerIsNotMember() {
+    Group group = createTestGroup(1L, "Private Group", false);
+    Authentication authentication = mock(Authentication.class);
+    User currentUser = createTestUser(5L, "User 5");
+    when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
+    when(authService.getCurrentUser()).thenReturn(currentUser);
+    when(groupMemberRepository.findByGroupIdAndUserId(1L, 5L)).thenReturn(Optional.empty());
+
+    assertThrows(
+        NotMemberException.class, () -> groupController.getGroupMembers(1L, authentication));
+  }
+
+  @Test
+  void shouldRejectGetPrivateGroupMembers_WhenUnauthenticated() {
+    Group group = createTestGroup(1L, "Private Group", false);
+    when(groupService.getGroupById(1L)).thenReturn(Optional.of(group));
+
+    assertThrows(UnauthorizedException.class, () -> groupController.getGroupMembers(1L, null));
   }
 
   @Test
@@ -304,7 +423,7 @@ class GroupControllerTest {
 
     when(authService.getCurrentUser()).thenReturn(currentUser);
     when(groupMemberRepository.findByGroupIdAndUserId(10L, 1L))
-        .thenReturn(Optional.of(mock(vaultWeb.models.GroupMember.class)));
+        .thenReturn(Optional.of(mock(GroupMember.class)));
     when(groupService.getMembers(10L)).thenReturn(List.of(member1, member2));
     when(deviceRepository.findByUserIn(List.of(member1, member2)))
         .thenReturn(List.of(device1, device2));
@@ -349,7 +468,7 @@ class GroupControllerTest {
 
     when(authService.getCurrentUser()).thenReturn(currentUser);
     when(groupMemberRepository.findByGroupIdAndUserId(10L, 1L))
-        .thenReturn(Optional.of(mock(vaultWeb.models.GroupMember.class)));
+        .thenReturn(Optional.of(mock(GroupMember.class)));
     when(chatMessageRepository.findByGroupIdAndDeletedFalseOrderByTimestampAsc(10L))
         .thenReturn(List.of(message));
 
@@ -402,10 +521,10 @@ class GroupControllerTest {
     assertEquals(10L, dto.getId());
     assertEquals("My Group", dto.getName());
     assertEquals(1, dto.getMembers().size());
-    // The response carries only the minimal user projection, never the User entity/password.
     assertEquals(2L, dto.getMembers().get(0).getUser().getId());
     assertEquals("friend", dto.getMembers().get(0).getUser().getUsername());
     assertEquals("USER", dto.getMembers().get(0).getRole());
+    verify(groupService, times(1)).getUserGroups(currentUser);
   }
 
   @Test

--- a/backend/src/test/java/vaultWeb/controllers/GroupControllerTest.java
+++ b/backend/src/test/java/vaultWeb/controllers/GroupControllerTest.java
@@ -284,8 +284,7 @@ class GroupControllerTest {
   @Test
   void shouldFailGetMembers_WhenGroupNotFound() {
     when(groupService.getGroupById(999L)).thenReturn(Optional.empty());
-    assertThrows(
-        GroupNotFoundException.class, () -> groupController.getGroupMembers(999L, null));
+    assertThrows(GroupNotFoundException.class, () -> groupController.getGroupMembers(999L, null));
     verify(groupService, times(1)).getGroupById(999L);
   }
 

--- a/backend/src/test/java/vaultWeb/services/GroupServiceTest.java
+++ b/backend/src/test/java/vaultWeb/services/GroupServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import vaultWeb.dtos.GroupDto;
 import vaultWeb.exceptions.AlreadyMemberException;
 import vaultWeb.exceptions.LastAdminException;
+import vaultWeb.exceptions.PrivateGroupJoinException;
 import vaultWeb.exceptions.notfound.GroupNotFoundException;
 import vaultWeb.exceptions.notfound.NotMemberException;
 import vaultWeb.exceptions.notfound.UserNotFoundException;
@@ -73,6 +74,18 @@ class GroupServiceTest {
 
     assertEquals(group, result);
     verify(groupMemberRepository, times(1)).save(any(GroupMember.class));
+  }
+
+  @Test
+  void shouldFailJoinGroup_WhenPrivateAndNotMember() {
+    User user = createUser(2L);
+    Group group = createGroup(10L, false);
+
+    when(groupRepository.findById(10L)).thenReturn(Optional.of(group));
+    when(groupMemberRepository.findByGroupAndUser(group, user)).thenReturn(Optional.empty());
+
+    assertThrows(PrivateGroupJoinException.class, () -> groupService.joinGroup(10L, user));
+    verify(groupMemberRepository, never()).save(any(GroupMember.class));
   }
 
   @Test


### PR DESCRIPTION


## Summary
- Prevent self-joining private groups without invitation/admin approval.
- Require membership for authenticated users accessing private group details and member lists.
- Keep public-group access available to authenticated users.
- Avoid a second group lookup in `getGroupMembers` by using the group already loaded for authorization.
- Add regression tests for private/public authorization and DTO mapping coverage.

## Security behavior
- Private groups cannot be self-joined through `joinGroup`.
- Private group details/member lists require authenticated membership.
- Public group details/member lists remain accessible to authenticated users.
- `isPublic` checks are null-safe and treat null as private.