### PR TITLE
Feature issue#341

### DIFF
--- a/backend/src/main/java/vaultWeb/controllers/ChatController.java
+++ b/backend/src/main/java/vaultWeb/controllers/ChatController.java
@@ -23,6 +23,12 @@ import vaultWeb.repositories.GroupMemberRepository;
 import vaultWeb.repositories.PrivateChatRepository;
 import vaultWeb.services.ChatService;
 
+/**
+ * Controller responsible for handling WebSocket-based chat functionality.
+ *
+ * <p>Supports both group chat and private messages. Messages are first persisted via ChatService
+ * and then dispatched to the corresponding topics or users.
+ */
 @Slf4j
 @Controller
 @RequiredArgsConstructor
@@ -33,6 +39,12 @@ public class ChatController {
   private final GroupMemberRepository groupMemberRepository;
   private final PrivateChatRepository privateChatRepository;
 
+  /**
+   * Handles incoming group chat messages from clients and broadcasts them to all subscribers of the
+   * specified group topic.
+   *
+   * @param messageDto DTO containing message content, sender information, and target group
+   */
   @MessageMapping("/chat.send")
   public void sendMessage(@Valid @Payload ChatMessageDto messageDto, Principal principal) {
     authorizeGroupMessage(messageDto, principal);
@@ -63,6 +75,12 @@ public class ChatController {
     messageDto.setSenderUsername(username);
   }
 
+  /**
+   * Handles incoming private chat messages from clients and sends them to both users of the private
+   * chat. The message content is end-to-end encrypted and never decrypted by the server.
+   *
+   * @param messageDto DTO containing message content, sender information, and private chat ID
+   */
   @MessageMapping("/chat.private.send")
   public void sendPrivateMessage(@Valid @Payload ChatMessageDto messageDto, Principal principal) {
     authorizePrivateMessage(messageDto, principal);

--- a/backend/src/main/java/vaultWeb/controllers/ChatController.java
+++ b/backend/src/main/java/vaultWeb/controllers/ChatController.java
@@ -15,14 +15,9 @@ import vaultWeb.dtos.ChatMessageDto;
 import vaultWeb.exceptions.UnauthorizedException;
 import vaultWeb.models.ChatMessage;
 import vaultWeb.repositories.GroupMemberRepository;
+import vaultWeb.repositories.PrivateChatRepository;
 import vaultWeb.services.ChatService;
 
-/**
- * Controller responsible for handling WebSocket-based chat functionality.
- *
- * <p>Supports both group chat and private messages. Messages are first persisted via ChatService
- * and then dispatched to the corresponding topics or users.
- */
 @Slf4j
 @Controller
 @RequiredArgsConstructor
@@ -31,13 +26,8 @@ public class ChatController {
   private final SimpMessagingTemplate messagingTemplate;
   private final ChatService chatService;
   private final GroupMemberRepository groupMemberRepository;
+  private final PrivateChatRepository privateChatRepository;
 
-  /**
-   * Handles incoming group chat messages from clients and broadcasts them to all subscribers of the
-   * specified group topic.
-   *
-   * @param messageDto DTO containing message content, sender information, and target group
-   */
   @MessageMapping("/chat.send")
   public void sendMessage(@Valid @Payload ChatMessageDto messageDto, Principal principal) {
     authorizeGroupMessage(messageDto, principal);
@@ -68,14 +58,9 @@ public class ChatController {
     messageDto.setSenderUsername(username);
   }
 
-  /**
-   * Handles incoming private chat messages from clients and sends them to both users of the private
-   * chat. The message content is end-to-end encrypted and never decrypted by the server.
-   *
-   * @param messageDto DTO containing message content, sender information, and private chat ID
-   */
   @MessageMapping("/chat.private.send")
-  public void sendPrivateMessage(@Valid @Payload ChatMessageDto messageDto) {
+  public void sendPrivateMessage(@Valid @Payload ChatMessageDto messageDto, Principal principal) {
+    authorizePrivateMessage(messageDto, principal);
     ChatMessage savedMessage = chatService.saveMessage(messageDto);
 
     ChatMessageDto responseDto = chatService.toDto(savedMessage);
@@ -94,5 +79,25 @@ public class ChatController {
         "Private message sent from {} to privateChat {}",
         responseDto.getSenderUsername(),
         responseDto.getPrivateChatId());
+  }
+
+  private void authorizePrivateMessage(ChatMessageDto messageDto, Principal principal) {
+    if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+      throw new UnauthorizedException("User not authenticated");
+    }
+    if (messageDto.getPrivateChatId() == null) {
+      throw new IllegalArgumentException("Private chat ID is required for private messages");
+    }
+
+    String username = principal.getName();
+    boolean isParticipant =
+        privateChatRepository.existsByIdAndParticipantUsername(
+            messageDto.getPrivateChatId(), username);
+    if (!isParticipant) {
+      throw new AccessDeniedException("Not allowed to send messages to this private chat");
+    }
+
+    messageDto.setSenderId(null);
+    messageDto.setSenderUsername(username);
   }
 }

--- a/backend/src/main/java/vaultWeb/controllers/ChatController.java
+++ b/backend/src/main/java/vaultWeb/controllers/ChatController.java
@@ -104,6 +104,8 @@ public class ChatController {
 
     messageDto.setSenderId(null);
     messageDto.setSenderUsername(username);
+  }
+
   @MessageMapping("/chat.delete")
   public void deleteMessage(@Payload String clientMessageId, Principal principal) {
 

--- a/backend/src/main/java/vaultWeb/repositories/PrivateChatRepository.java
+++ b/backend/src/main/java/vaultWeb/repositories/PrivateChatRepository.java
@@ -3,6 +3,8 @@ package vaultWeb.repositories;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import vaultWeb.models.PrivateChat;
 import vaultWeb.models.User;
 
@@ -12,4 +14,10 @@ public interface PrivateChatRepository extends JpaRepository<PrivateChat, Long> 
   Optional<PrivateChat> findByUser2AndUser1(User user1, User user2);
 
   List<PrivateChat> findByUser1OrUser2(User user1, User user2);
+
+  @Query(
+      "SELECT CASE WHEN COUNT(pc) > 0 THEN true ELSE false END FROM PrivateChat pc "
+          + "WHERE pc.id = :id AND (pc.user1.username = :username OR pc.user2.username = :username)")
+  boolean existsByIdAndParticipantUsername(
+      @Param("id") Long id, @Param("username") String username);
 }

--- a/backend/src/test/java/vaultWeb/controllers/ChatControllerTest.java
+++ b/backend/src/test/java/vaultWeb/controllers/ChatControllerTest.java
@@ -21,8 +21,10 @@ import vaultWeb.dtos.ChatMessageDto;
 import vaultWeb.exceptions.UnauthorizedException;
 import vaultWeb.models.ChatMessage;
 import vaultWeb.models.Group;
+import vaultWeb.models.PrivateChat;
 import vaultWeb.models.User;
 import vaultWeb.repositories.GroupMemberRepository;
+import vaultWeb.repositories.PrivateChatRepository;
 import vaultWeb.services.ChatService;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,6 +38,8 @@ class ChatControllerTest {
   @Mock private ChatService chatService;
 
   @Mock private GroupMemberRepository groupMemberRepository;
+
+  @Mock private PrivateChatRepository privateChatRepository;
 
   @InjectMocks private ChatController chatController;
 
@@ -81,9 +85,91 @@ class ChatControllerTest {
     verify(messagingTemplate, never()).convertAndSend(any(String.class), any(ChatMessageDto.class));
   }
 
+  @Test
+  void shouldSendPrivateMessage_WhenAuthenticatedUserIsParticipant() {
+    ChatMessageDto request = createPrivateMessageRequest(20L);
+    Principal principal = () -> "alice";
+    ChatMessage savedMessage = createSavedPrivateMessage(20L, "alice", "bob");
+    ChatMessageDto response = createPrivateMessageRequest(20L);
+    response.setSenderUsername("alice");
+
+    when(privateChatRepository.existsByIdAndParticipantUsername(20L, "alice")).thenReturn(true);
+    when(chatService.saveMessage(any(ChatMessageDto.class))).thenReturn(savedMessage);
+    when(chatService.toDto(savedMessage)).thenReturn(response);
+
+    chatController.sendPrivateMessage(request, principal);
+
+    ArgumentCaptor<ChatMessageDto> dtoCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+    verify(chatService).saveMessage(dtoCaptor.capture());
+    assertEquals("alice", dtoCaptor.getValue().getSenderUsername());
+    verify(messagingTemplate)
+        .convertAndSendToUser(eq("alice"), eq("/queue/private"), any(ChatMessageDto.class));
+    verify(messagingTemplate)
+        .convertAndSendToUser(eq("bob"), eq("/queue/private"), any(ChatMessageDto.class));
+  }
+
+  @Test
+  void shouldRejectPrivateMessage_WhenAuthenticatedUserIsNotParticipant() {
+    // Mallory is not a participant of private chat 20 (alice/bob), and attempts to
+    // inject a message while spoofing "alice" as the sender in the payload.
+    ChatMessageDto request = createPrivateMessageRequest(20L);
+    Principal principal = () -> "mallory";
+
+    when(privateChatRepository.existsByIdAndParticipantUsername(20L, "mallory")).thenReturn(false);
+
+    assertThrows(
+        AccessDeniedException.class, () -> chatController.sendPrivateMessage(request, principal));
+    verify(chatService, never()).saveMessage(any());
+    verify(messagingTemplate, never())
+        .convertAndSendToUser(any(String.class), any(String.class), any(ChatMessageDto.class));
+  }
+
+  @Test
+  void shouldRejectPrivateMessage_WhenUnauthenticated() {
+    ChatMessageDto request = createPrivateMessageRequest(20L);
+
+    assertThrows(
+        UnauthorizedException.class, () -> chatController.sendPrivateMessage(request, null));
+    verify(privateChatRepository, never()).existsByIdAndParticipantUsername(any(), any());
+    verify(chatService, never()).saveMessage(any());
+    verify(messagingTemplate, never())
+        .convertAndSendToUser(any(String.class), any(String.class), any(ChatMessageDto.class));
+  }
+
+  @Test
+  void shouldOverwriteSenderUsername_WithPrincipalName_NotSpoofedPayloadValue() {
+    // request carries a spoofed sender ("spoofed-sender" from the helper); confirm the
+    // dto passed to saveMessage carries the authenticated principal's name instead.
+    ChatMessageDto request = createPrivateMessageRequest(20L);
+    Principal principal = () -> "alice";
+    ChatMessage savedMessage = createSavedPrivateMessage(20L, "alice", "bob");
+    ChatMessageDto response = createPrivateMessageRequest(20L);
+    response.setSenderUsername("alice");
+
+    when(privateChatRepository.existsByIdAndParticipantUsername(20L, "alice")).thenReturn(true);
+    when(chatService.saveMessage(any(ChatMessageDto.class))).thenReturn(savedMessage);
+    when(chatService.toDto(savedMessage)).thenReturn(response);
+
+    chatController.sendPrivateMessage(request, principal);
+
+    ArgumentCaptor<ChatMessageDto> dtoCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+    verify(chatService).saveMessage(dtoCaptor.capture());
+    assertEquals("alice", dtoCaptor.getValue().getSenderUsername());
+    assertEquals(null, dtoCaptor.getValue().getSenderId());
+  }
+
   private ChatMessageDto createGroupMessageRequest(Long groupId) {
     ChatMessageDto dto = new ChatMessageDto();
     dto.setGroupId(groupId);
+    dto.setSenderUsername("spoofed-sender");
+    dto.setSenderDeviceId(SENDER_DEVICE_ID);
+    dto.setE2eePayload(E2EE_PAYLOAD);
+    return dto;
+  }
+
+  private ChatMessageDto createPrivateMessageRequest(Long privateChatId) {
+    ChatMessageDto dto = new ChatMessageDto();
+    dto.setPrivateChatId(privateChatId);
     dto.setSenderUsername("spoofed-sender");
     dto.setSenderDeviceId(SENDER_DEVICE_ID);
     dto.setE2eePayload(E2EE_PAYLOAD);
@@ -97,6 +183,29 @@ class ChatControllerTest {
     group.setId(groupId);
     ChatMessage message = new ChatMessage();
     message.setGroup(group);
+    message.setSender(sender);
+    message.setSenderDeviceId(SENDER_DEVICE_ID);
+    message.setE2eePayload(E2EE_PAYLOAD);
+    message.setTimestamp(java.time.Instant.parse("2026-03-26T10:15:30Z"));
+    return message;
+  }
+
+  private ChatMessage createSavedPrivateMessage(
+      Long privateChatId, String user1Username, String user2Username) {
+    User user1 = new User();
+    user1.setUsername(user1Username);
+    User user2 = new User();
+    user2.setUsername(user2Username);
+    PrivateChat privateChat = new PrivateChat();
+    privateChat.setId(privateChatId);
+    privateChat.setUser1(user1);
+    privateChat.setUser2(user2);
+
+    User sender = new User();
+    sender.setUsername(user1Username);
+
+    ChatMessage message = new ChatMessage();
+    message.setPrivateChat(privateChat);
     message.setSender(sender);
     message.setSenderDeviceId(SENDER_DEVICE_ID);
     message.setE2eePayload(E2EE_PAYLOAD);

--- a/backend/src/test/java/vaultWeb/controllers/ChatControllerTest.java
+++ b/backend/src/test/java/vaultWeb/controllers/ChatControllerTest.java
@@ -160,7 +160,8 @@ class ChatControllerTest {
     verify(chatService).saveMessage(dtoCaptor.capture());
     assertEquals("alice", dtoCaptor.getValue().getSenderUsername());
     assertEquals(null, dtoCaptor.getValue().getSenderId());
-  // --- deleteMessage ---
+    // --- deleteMessage ---
+  }
 
   @Test
   void shouldBroadcastGroupDelete_toDedicatedDeletedTopic_notNormalMessageTopic() {
@@ -271,6 +272,15 @@ class ChatControllerTest {
 
     User sender = new User();
     sender.setUsername(user1Username);
+
+    ChatMessage message = new ChatMessage();
+    message.setPrivateChat(privateChat);
+    message.setSender(sender);
+    message.setSenderDeviceId(SENDER_DEVICE_ID);
+    message.setE2eePayload(E2EE_PAYLOAD);
+    message.setTimestamp(java.time.Instant.parse("2026-03-26T10:15:30Z"));
+    return message;
+  }
 
   private ChatMessage createSavedPrivateMessage(String username1, String username2) {
     User sender = new User();


### PR DESCRIPTION
## Summary

`sendPrivateMessage` (WebSocket handler for `/app/chat.private.send`) trusted `senderId`/`senderUsername` directly from the client payload and had no check that the caller was actually a participant of the target `privateChatId`. This allowed any authenticated client to impersonate another user and inject messages into any private chat by ID — the same class of bug fixed for the REST layer in #314, but never applied to this WebSocket path.

Fixed by mirroring the existing group-chat authorization pattern (`authorizeGroupMessage`) with a new `authorizePrivateMessage`:
- Added `Principal principal` param to `sendPrivateMessage`
- Added `PrivateChatRepository.existsByIdAndParticipantUsername(id, username)` to check the caller is `user1` or `user2` on the target private chat
- `senderId`/`senderUsername` are now always overwritten from `principal.getName()` before the message reaches `ChatService.saveMessage`, discarding whatever the client sent
- Unauthorized sends now throw `AccessDeniedException` before anything is persisted or broadcast

## Linked issue

Closes #341

## How to test

**Unit tests** (added to `ChatControllerTest`):
- `shouldSendPrivateMessage_WhenAuthenticatedUserIsParticipant` — happy path, both participants receive the broadcast
- `shouldRejectPrivateMessage_WhenAuthenticatedUserIsNotParticipant` — regression test for the exploit: a non-participant is rejected, nothing is saved or sent
- `shouldRejectPrivateMessage_WhenUnauthenticated` — no principal → `UnauthorizedException`
- `shouldOverwriteSenderUsername_WithPrincipalName_NotSpoofedPayloadValue` — confirms a spoofed `senderUsername`/`senderId` in the payload never reaches `saveMessage`

Run: `./mvnw test -Dtest=ChatControllerTest` (or full suite, since `PrivateChatRepository` and `ChatController`'s constructor both changed).

**Manual/STOMP verification** (repro from the issue, now blocked):
1. Connect as an authenticated user who is *not* a participant of a target private chat
2. `SEND` to `/app/chat.private.send` with that chat's `privateChatId` and `senderUsername` set to a real participant
3. Expect rejection at the handler and confirm no row is written to `chat_message`

Also manually smoke-tested normal private chat send/receive between two real participants, and group chat send, to confirm no regression in either path.

## Notes / Risk

- No schema migration — only a new repository query method (JPQL `@Query`, no new column/index).
- No feature flag; this is a straight security fix with no behavior change for legitimate senders.
- `ChatController`'s constructor gained a new dependency (`PrivateChatRepository`) — anything else that mocks/constructs `ChatController` directly (rather than via Spring) will need to supply it.
- `existsByIdAndParticipantUsername` returns `false` uniformly for both "chat doesn't exist" and "caller isn't a participant," so the client can't distinguish the two from the error — this is intentional (avoids leaking chat existence) but worth being aware of if any future caller wants a different error for a bad ID vs. a permission failure.