### PR TITLE
Feature issue#342

### DIFF
--- a/backend/src/main/java/vaultWeb/controllers/DashboardController.java
+++ b/backend/src/main/java/vaultWeb/controllers/DashboardController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,8 +41,21 @@ public class DashboardController {
   @GetMapping("/{username}")
   @Operation(
       summary = "Get dashboard data for a specific user",
-      description = "Primarily useful for admin tooling or debugging in the UI.")
+      description =
+          "Returns dashboard data only when the requested username matches the authenticated "
+              + "caller. There is no global-admin role in this system to gate broader access "
+              + "on (roles here are scoped per-group via GroupMember/@AdminOnly), so this "
+              + "endpoint cannot safely support cross-user lookups. Prefer /api/dashboard/me.")
   public ResponseEntity<UserDashboardDto> getDashboardForUser(@PathVariable String username) {
+    User currentUser = authService.getCurrentUser();
+    if (currentUser == null) {
+      throw new UnauthorizedException("User is not authenticated");
+    }
+
+    if (!currentUser.getUsername().equals(username)) {
+      throw new AccessDeniedException("Not allowed to view this user's dashboard");
+    }
+
     User targetUser =
         userRepository
             .findByUsername(username)

--- a/backend/src/test/java/vaultWeb/controllers/DashboardControllerTest.java
+++ b/backend/src/test/java/vaultWeb/controllers/DashboardControllerTest.java
@@ -1,6 +1,10 @@
 package vaultWeb.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -12,7 +16,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import vaultWeb.dtos.dashboard.UserDashboardDto;
+import vaultWeb.exceptions.UnauthorizedException;
+import vaultWeb.exceptions.notfound.UserNotFoundException;
 import vaultWeb.models.User;
 import vaultWeb.repositories.UserRepository;
 import vaultWeb.services.DashboardService;
@@ -49,14 +56,16 @@ class DashboardControllerTest {
   }
 
   @Test
-  void shouldReturnDashboardForSpecificUser() {
+  void shouldReturnDashboardForSpecificUser_WhenRequestingOwnUsername() {
     // Arrange
     String username = "test_user";
     User user = new User();
+    user.setUsername(username);
 
     UserDashboardDto dashboardDto =
         new UserDashboardDto(null, List.of(), List.of(), List.of(), List.of());
 
+    when(authService.getCurrentUser()).thenReturn(user);
     when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
     when(dashboardService.buildDashboard(user)).thenReturn(dashboardDto);
 
@@ -66,5 +75,45 @@ class DashboardControllerTest {
     // Assert
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(dashboardDto, response.getBody());
+  }
+
+  @Test
+  void shouldRejectDashboard_WhenRequestingAnotherUsersUsername() {
+    // Regression test for #342: an authenticated user must not be able to view
+    // another user's dashboard by requesting GET /api/dashboard/{their-username}.
+    User mallory = new User();
+    mallory.setUsername("mallory");
+
+    when(authService.getCurrentUser()).thenReturn(mallory);
+
+    assertThrows(
+        AccessDeniedException.class, () -> dashboardController.getDashboardForUser("alice"));
+    verify(userRepository, never()).findByUsername(any());
+    verify(dashboardService, never()).buildDashboard(any());
+  }
+
+  @Test
+  void shouldRejectDashboard_WhenUnauthenticated() {
+    when(authService.getCurrentUser()).thenReturn(null);
+
+    assertThrows(
+        UnauthorizedException.class, () -> dashboardController.getDashboardForUser("alice"));
+    verify(userRepository, never()).findByUsername(any());
+    verify(dashboardService, never()).buildDashboard(any());
+  }
+
+  @Test
+  void shouldThrowUserNotFound_WhenOwnUsernameLookupFails() {
+    // Edge case: currentUser passes the self-check but the repository lookup for
+    // that same username somehow misses (stale session, race with deletion, etc.).
+    String username = "test_user";
+    User user = new User();
+    user.setUsername(username);
+
+    when(authService.getCurrentUser()).thenReturn(user);
+    when(userRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+    assertThrows(
+        UserNotFoundException.class, () -> dashboardController.getDashboardForUser(username));
   }
 }


### PR DESCRIPTION
## Summary

`GET /api/dashboard/{username}` had no authorization check — `getDashboardForUser` looked up any requested username and returned their full dashboard (group memberships/roles, private chat partner usernames, poll participation, message counts) with no verification that the caller owned that username or had elevated privileges.

Investigated whether an existing admin mechanism could gate this instead of removing the endpoint's cross-user capability entirely. Found that this codebase's only role concept (`Role.ADMIN`/`Role.USER`) is scoped per-`GroupMember` — enforced via `@AdminOnly`/`AdminOnlyAspect`, which requires a `groupId` to check a user's role *within that specific group*. There is no global-admin concept anywhere in the system that could legitimately gate "can user X view user Y's unrelated dashboard." Inventing one wasn't appropriate scope for a security fix.

Fixed by restricting `getDashboardForUser` to self-only access: it now resolves the caller's identity via `authService.getCurrentUser()` (the same trusted source `/api/dashboard/me` already uses) and rejects the request unless the caller's own username matches the requested path variable.

This makes the endpoint functionally redundant with `/api/dashboard/me` — flagging that explicitly below rather than silently leaving overlapping endpoints in place.

## Linked issue

Closes #342

## How to test

**Unit tests** (`DashboardControllerTest`):
- `shouldReturnDashboardForCurrentUser` — existing, unaffected
- `shouldReturnDashboardForSpecificUser_WhenRequestingOwnUsername` — updated from the original (which never stubbed `getCurrentUser()`, since the old code never called it) to reflect the new self-check
- `shouldRejectDashboard_WhenRequestingAnotherUsersUsername` — **regression test**: an authenticated user requesting a different username gets `AccessDeniedException`, and neither the repository lookup nor `buildDashboard` is ever invoked
- `shouldRejectDashboard_WhenUnauthenticated` — no current user → `UnauthorizedException`
- `shouldThrowUserNotFound_WhenOwnUsernameLookupFails` — self-check passes but repository lookup misses (stale session edge case)

Run: `./mvnw test -Dtest=DashboardControllerTest`

**Manual verification** (repro from the issue, now blocked):
1. Authenticate as user A, obtain a JWT
2. `GET /api/dashboard/{userB}` for a username that isn't A's own
3. Expect `403 Forbidden` instead of user B's dashboard data
4. Confirm `GET /api/dashboard/{ownUsername}` and `GET /api/dashboard/me` both still return correctly for the authenticated user

## Notes / Risk

- No schema migration — no new fields, no new tables.
- No feature flag; straight security fix, no behavior change for legitimate self-access.
- **Breaking change for any existing client** relying on `GET /api/dashboard/{username}` to view *another* user's dashboard for legitimate admin/debugging purposes — that capability is fully removed, not just gated, since no real authorization boundary exists to gate it on. If admin tooling genuinely needs cross-user dashboard access, that requires a separate design discussion (introducing a real global-admin role) rather than this fix.
- Endpoint is now redundant with `/api/dashboard/me` (same result, reached via path variable instead of implicit caller identity) — worth a maintainer call on whether to deprecate/remove `getDashboardForUser` entirely in a follow-up rather than keep both.
- Confirm `AccessDeniedException` is already mapped to a 403 response globally (Spring Security default, or via `GlobalExceptionHandler`) — not verified against the actual handler config in this PR.